### PR TITLE
fix for component without props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,8 @@ module.exports = function(createStore) {
 
             props = props || {};
 
-            var initialState = props.initialState;
-            var initialProps = props.initialProps;
+            var initialState = props.initialState || {};
+            var initialProps = props.initialProps || {};
             var hasStore = props.store && props.store.dispatch && props.store.getState;
             var store = hasStore
                 ? props.store


### PR DESCRIPTION
When you pass a component without props it shows the following error:

`TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at WrappedCmp (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/next-redux-wrapper/src/index.js:56:20)
    at /Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactCompositeComponent.js:306:16
    at measureLifeCyclePerf (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactCompositeComponent.js:75:12)
    at ReactCompositeComponentWrapper._constructComponentWithoutOwner (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactCompositeComponent.js:305:14)
    at ReactCompositeComponentWrapper._constructComponent (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactCompositeComponent.js:280:21)
    at ReactCompositeComponentWrapper.mountComponent (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactCompositeComponent.js:188:21)
    at Object.mountComponent (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactReconciler.js:46:35)
    at ReactCompositeComponentWrapper.performInitialMount (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactCompositeComponent.js:371:34)
    at ReactCompositeComponentWrapper.mountComponent (/Users/DLYA/Desktop/DLYA/BDevelopers/bd-admin-front/node_modules/react-dom/lib/ReactCompositeComponent.js:258:21)`