### PR TITLE
Also memoize store on server to make withRedux work with child components

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ export default Page;
 ## How it works
 
 No magic is involved, it auto-creates Redux store when `getInitialProps` is called by Next.js and then passes this store
-down to React Redux's `Provider`, which is used to wrap the original component, also automatically. On the client side
-it also takes care of using same store every time, whereas on server new store is created for each request.
+down to React Redux's `Provider`, which is used to wrap the original component, also automatically.
+The same store is used on server on client when rendering child components.
 
 The `withRedux` function accepts `makeStore` as first argument, all other arguments are internally passed to React
 Redux's `connect()` function for simplicity. The `makeStore` function will receive initial state as one argument and

--- a/src/index.js
+++ b/src/index.js
@@ -10,22 +10,20 @@ var _debug = false;
 var skipMerge = ['initialState', 'initialProps', 'isServer', 'store'];
 
 function initStore(makeStore, req, initialState) {
+  if (!memoizedStore) {
+      memoizedStore = makeStore(initialState);
+  }
 
-    // Always make a new store if server
-    if (!!req && typeof window === 'undefined') {
-        if (!req._store) {
-            req._store = makeStore(initialState);
-        }
-        return req._store;
-    }
+  if (!!req && typeof window === 'undefined') {
+      // Make sure the memoized store is attached to the request.
+      if (!req._store) {
+          req._store = memoizedStore;
+      }
 
-    // Memoize store if client
-    if (!memoizedStore) {
-        memoizedStore = makeStore(initialState);
-    }
+      return req._store;
+  }
 
-    return memoizedStore;
-
+  return memoizedStore;
 }
 
 module.exports = function(createStore) {


### PR DESCRIPTION
For some reason the redux store was not memoized on the server side, instead a new one was created every time. This caused child components, nested deeper inside a next.js Page component, to render off of an empty state.

The tests still pass and this #23 for us.

Sorry if there was a specific reason to not memoized the store on the server side and if this breaks anything. Also, more code in `WrappedCmp` might need to be adjusted, not 100% sure about this.