### PR TITLE
Add config parameter, optional mapInitialProps method

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -17,6 +17,12 @@ exports[`test async store integration 1`] = `
 </div>
 `;
 
+exports[`test map initial props 1`] = `
+<div>
+  bar
+</div>
+`;
+
 exports[`test simple props 1`] = `
 <div>
   foo

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ module.exports = function(createStore) {
 
     var config = {storeKey: DEFAULT_KEY, debug: false};
     var connectArgs;
+    var mapInitialProps;
 
     // Ensure backwards compatibility, the config object should come last after connect arguments.
     if (typeof createStore === 'object') {
@@ -59,6 +60,10 @@ module.exports = function(createStore) {
 
         if (({}).hasOwnProperty.call(wrappedConfig, 'storeKey')) {
             config.storeKey = wrappedConfig.storeKey;
+        }
+
+        if (({}).hasOwnProperty.call(wrappedConfig, 'mapInitialProps')) {
+          mapInitialProps = wrappedConfig.mapInitialProps;
         }
 
         // Map the connect arguments from the passed in config object.
@@ -86,6 +91,7 @@ module.exports = function(createStore) {
 
             var initialState = props.initialState || {};
             var initialProps = props.initialProps || {};
+            var mappedInitialProps = mapInitialProps ? mapInitialProps(initialProps) : initialProps;
             var hasStore = props.store && props.store.dispatch && props.store.getState;
             var store = hasStore
                 ? props.store
@@ -96,7 +102,7 @@ module.exports = function(createStore) {
             // Fix for _document
             var mergedProps = {};
             Object.keys(props).forEach(function(p) { if (!~skipMerge.indexOf(p)) mergedProps[p] = props[p]; });
-            Object.keys(initialProps || {}).forEach(function(p) { mergedProps[p] = initialProps[p]; });
+            Object.keys(mappedInitialProps || {}).forEach(function(p) { mergedProps[p] = mappedInitialProps[p]; });
 
             return React.createElement( //FIXME This will create double Provider for _document case
                 Provider,

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -98,3 +98,18 @@ test('advanced props', () => {
     expect(component.toJSON()).toMatchSnapshot();
 
 });
+
+test('map initial props', () => {
+    const App = ({foo}) => (<div>{foo}</div>);
+    const WrappedApp = wrapper({
+        createStore: makeStore,
+        mapStateToProps: (state) => state,
+        mapInitialProps: (props) => {
+            props.foo = 'bar';
+            return props;
+        }
+    })(App);
+
+    const component = renderer.create(<WrappedApp foo="foo"/>);
+    expect(component.toJSON()).toMatchSnapshot();
+});


### PR DESCRIPTION
This change is open for discussion, happy if its doesn't make sense for the main project. It adds the ability to optionally pass, with the new config block, a method `mapInitialProps` which is passed the `initalProps` of the wrapped Page. 

This is something that helps meets a use case of mine. The rational for putting this method into `next-redux-wrapper` is:

the `props` on first page load, before passing to the page component, are parsed from the server side generated state. However if the objects in the props were instances of specific classes, they are simply serialised into the page, and subsequently there is currently no way to rehydrate them back to an instance of the specific type on first page load before the props are passed to the component. One could just do the necessary reconstruct logic inside the page component constructor and manipulate the props there, but I wanted a solution which would abstract this away from the component implementation themselves. 

With the proposed addition I should be able to say for example, instead of wrapping the page with the `next-redux-wrapper` wrapper directly I could wrap it with `function wrapAndRehydrate(makeStore) { return wrapper({createStore: makeStore, mapInitialProps: (props} => <do some stuff to rehydrate instances here>); }` and get towards what I was describing above.
