### PR TITLE
Add tests and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Redux wrapper for Next.js
 =========================
-[Build status](https://travis-ci.org/kirill-konshin/next-redux-wrapper.svg?branch=master)
+![Build status](https://travis-ci.org/kirill-konshin/next-redux-wrapper.svg?branch=master)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Redux wrapper for Next.js
 =========================
+[Build status](https://travis-ci.org/kirill-konshin/next-redux-wrapper.svg?branch=master)
 
 ## Usage
 
@@ -69,6 +70,24 @@ Redux's `connect()` function for simplicity. The `makeStore` function will recei
 should return a new instance of redux store each time when called, no memoization needed here, it is automatically done
 inside the wrapper.
 
+`withRedux` also optionally accepts an object. In this case only 1 parameter is passed which can contain the following
+configuration properties:
+
+- `createStore` (required, function) : the `makerStore` function as described above
+- `storeKey` (optional, string) : the key used on `window` to persist the store on the client
+- `debug` (optional, boolean) : enable debug logging
+- `mapStateToProps`, `mapDispatchToProps`, `mergeProps` (optional, functions) : functions to pass to `react-redux` `connect` method
+- `connectOptions` (optional, object) : configuration to pass to `react-redux` `connect` method
+
+
+When `makeStore` is invoked it is also provided a configuration object as the second parameter, which includes:
+
+- `isServer` (boolean): `true` if called while on the server rather than the client
+- `req` (Request): The `next.js` `getInitialProps` context `req` parameter
+- `query` (object): The `next.js` `getInitialProps` context `query` parameter
+
+The object also includes all configuration as passed to `withRedux` if called with an object of configuration properties.
+
 **Use `withRedux` to wrap only top level pages! All other components should keep using regular `connect` function of
 React Redux.**
 
@@ -129,3 +148,4 @@ Here you can find better ways to detect if an object is Immutable.JS: https://st
 * [next-redux-saga](https://github.com/bmealhouse/next-redux-saga)
 * [How to use with Redux and Redux Saga](https://www.robinwieruch.de/nextjs-redux-saga/)
 * Redux Saga Example: https://gist.github.com/pesakitan22/94b4984140ba0f2c9e52c5289a7d833e.
+* [Typescript type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/next-redux-wrapper) > `npm install @types/next-redux-wrapper`

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "babel-jest": "^18.0.0",
     "babel-preset-react-app": "^2.1.0",
-    "jest": "^18.1.0",
+    "jest": "^20.0.4",
     "next": "^2.0.0-beta.24",
     "react": "^15.4.2",
     "react-redux": "^5.0.2",
@@ -37,7 +37,8 @@
   "license": "MIT",
   "jest": {
     "testRegex": "(/src/.*\\.spec.js)$",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "testEnvironment": "jsdom"
   },
   "babel": {
     "presets": [

--- a/src/__snapshots__/index.server.spec.js.snap
+++ b/src/__snapshots__/index.server.spec.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createStore On the server setup store on server and use next.js page context params 1`] = `<div />`;
+
+exports[`createStore On the server should create new store for server each time 1`] = `<div />`;

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -1,36 +1,48 @@
-exports[`test advanced props 1`] = `
-<div>
-  foo
-</div>
-`;
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test async store integration 1`] = `
+exports[`async store integration 1`] = `
 <div>
   <div
-    className="redux">
+    className="redux"
+  >
     foo
   </div>
   <div
-    className="custom">
+    className="custom"
+  >
     custom
   </div>
 </div>
 `;
 
-exports[`test simple props 1`] = `
+exports[`createStore advanced props 1`] = `
 <div>
   foo
 </div>
 `;
 
-exports[`test simple store integration 1`] = `
+exports[`createStore debug mode from options 1`] = `<div />`;
+
+exports[`createStore debug mode with setDebug method 1`] = `<div />`;
+
+exports[`createStore should be able to configure store key on window 1`] = `<div />`;
+
+exports[`createStore simple props 1`] = `
+<div>
+  foo
+</div>
+`;
+
+exports[`simple store integration 1`] = `
 <div>
   <div
-    className="redux">
+    className="redux"
+  >
     foo
   </div>
   <div
-    className="custom">
+    className="custom"
+  >
     custom
   </div>
 </div>

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -17,6 +17,12 @@ exports[`test async store integration 1`] = `
 </div>
 `;
 
+exports[`test map initial props 1`] = `
+<div>
+  bar
+</div>
+`;
+
 exports[`test simple props 1`] = `
 <div>
   foo

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -17,12 +17,6 @@ exports[`test async store integration 1`] = `
 </div>
 `;
 
-exports[`test map initial props 1`] = `
-<div>
-  bar
-</div>
-`;
-
 exports[`test simple props 1`] = `
 <div>
   foo

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ function initStore(makeStore, initialState, context, config) {
 
 module.exports = function(createStore) {
 
-    var config = {storeKey: DEFAULT_KEY, debug: false};
+    var config = {storeKey: DEFAULT_KEY, debug: _debug};
     var connectArgs;
 
     // Ensure backwards compatibility, the config object should come last after connect arguments.
@@ -74,8 +74,6 @@ module.exports = function(createStore) {
         connectArgs = [].slice.call(arguments).slice(1);
     }
 
-    var debug = _debug || config.debug;
-
     return function(Cmp) {
 
         // Since provide should always be after connect we connect here
@@ -92,7 +90,7 @@ module.exports = function(createStore) {
                 ? props.store
                 : initStore(createStore, initialState, {}, config); // client case, no store but has initialState
 
-            if (debug) console.log(Cmp.name, '- 4. WrappedCmp.render', (hasStore ? 'picked up existing one,' : 'created new store with'), 'initialState', initialState);
+            if (config.debug) console.log(Cmp.name, '- 4. WrappedCmp.render', (hasStore ? 'picked up existing one,' : 'created new store with'), 'initialState', initialState);
 
             // Fix for _document
             var mergedProps = {};
@@ -113,7 +111,7 @@ module.exports = function(createStore) {
 
                 ctx = ctx || {};
 
-                if (debug) console.log(Cmp.name, '- 1. WrappedCmp.getInitialProps wrapper', (ctx.req && ctx.req._store ? 'takes the req store' : 'creates the store'));
+                if (config.debug) console.log(Cmp.name, '- 1. WrappedCmp.getInitialProps wrapper', (ctx.req && ctx.req._store ? 'takes the req store' : 'creates the store'));
 
                 ctx.isServer = !!ctx.req;
                 ctx.store = initStore(createStore, undefined /** initialState **/, {req: ctx.req, query: ctx.query}, config);
@@ -127,7 +125,7 @@ module.exports = function(createStore) {
 
             }).then(function(arr) {
 
-                if (debug) console.log(Cmp.name, '- 3. WrappedCmp.getInitialProps has store state', arr[1].getState());
+                if (config.debug) console.log(Cmp.name, '- 3. WrappedCmp.getInitialProps has store state', arr[1].getState());
 
                 return {
                     isServer: arr[0],

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ module.exports = function(createStore) {
 
     var config = {storeKey: DEFAULT_KEY, debug: false};
     var connectArgs;
+    var mapInitialProps;
 
     // Ensure backwards compatibility, the config object should come last after connect arguments.
     if (typeof createStore === 'object') {
@@ -59,6 +60,10 @@ module.exports = function(createStore) {
 
         if (({}).hasOwnProperty.call(wrappedConfig, 'storeKey')) {
             config.storeKey = wrappedConfig.storeKey;
+        }
+
+        if (({}).hasOwnProperty.call(wrappedConfig, 'mapInitialProps')) {
+          mapInitialProps = wrappedConfig.mapInitialProps;
         }
 
         // Map the connect arguments from the passed in config object.
@@ -86,6 +91,7 @@ module.exports = function(createStore) {
 
             var initialState = props.initialState || {};
             var initialProps = props.initialProps || {};
+            var mappedInitialProps = mapInitialProps ? mapInitialProps(initialProps) : initialProps;
             var hasStore = props.store && props.store.dispatch && props.store.getState;
             var store = hasStore
                 ? props.store
@@ -96,7 +102,7 @@ module.exports = function(createStore) {
             // Fix for _document
             var mergedProps = {};
             Object.keys(props).forEach(function(p) { if (!~skipMerge.indexOf(p)) mergedProps[p] = props[p]; });
-            Object.keys(initialProps || {}).forEach(function(p) { mergedProps[p] = initialProps[p]; });
+            Object.keys(mappedInitialProps || {}).forEach(function(p) { mergedProps[p] = mappedInitialProps[p]; });
 
             return React.createElement( //FIXME This will create double Provider for _document case
                 Provider,

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,6 @@ module.exports = function(createStore) {
 
     var config = {storeKey: DEFAULT_KEY, debug: false};
     var connectArgs;
-    var mapInitialProps;
 
     // Ensure backwards compatibility, the config object should come last after connect arguments.
     if (typeof createStore === 'object') {
@@ -61,10 +60,6 @@ module.exports = function(createStore) {
 
         if (({}).hasOwnProperty.call(wrappedConfig, 'storeKey')) {
             config.storeKey = wrappedConfig.storeKey;
-        }
-
-        if (({}).hasOwnProperty.call(wrappedConfig, 'mapInitialProps')) {
-          mapInitialProps = wrappedConfig.mapInitialProps;
         }
 
         // Map the connect arguments from the passed in config object.
@@ -92,7 +87,6 @@ module.exports = function(createStore) {
 
             var initialState = props.initialState || {};
             var initialProps = props.initialProps || {};
-            var mappedInitialProps = mapInitialProps ? mapInitialProps(initialProps) : initialProps;
             var hasStore = props.store && props.store.dispatch && props.store.getState;
             var store = hasStore
                 ? props.store
@@ -103,7 +97,7 @@ module.exports = function(createStore) {
             // Fix for _document
             var mergedProps = {};
             Object.keys(props).forEach(function(p) { if (!~skipMerge.indexOf(p)) mergedProps[p] = props[p]; });
-            Object.keys(mappedInitialProps || {}).forEach(function(p) { mergedProps[p] = mappedInitialProps[p]; });
+            Object.keys(initialProps || {}).forEach(function(p) { mergedProps[p] = initialProps[p]; });
 
             return React.createElement( //FIXME This will create double Provider for _document case
                 Provider,

--- a/src/index.server.spec.js
+++ b/src/index.server.spec.js
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+
+import React from "react";
+import {applyMiddleware, createStore} from "redux";
+import promiseMiddleware from "redux-promise-middleware";
+import renderer from "react-test-renderer";
+import wrapper from "./index";
+
+const makeStore = (initialState) => {
+  return createStore((s) => s, initialState, applyMiddleware(promiseMiddleware()));
+};
+
+describe('createStore', () => {
+    describe('On the server', () => {
+        test('should create new store for server each time', async () => {
+            const mock = jest.fn().mockReturnValue(makeStore({}));
+            const App = ({foo}) => (<div>{foo}</div>);
+            const WrappedApp = wrapper(mock)(App);
+            const component = renderer.create(<WrappedApp store={makeStore({})}/>);
+            await WrappedApp.getInitialProps({
+                req: {}
+            });
+            expect(component.toJSON()).toMatchSnapshot();
+            await WrappedApp.getInitialProps({
+                req: {}
+            });
+            expect(mock).toHaveBeenCalledTimes(2);
+        });
+
+        test('setup store on server and use next.js page context params', async () => {
+            const App = ({foo}) => (<div>{foo}</div>);
+            const WrappedApp = wrapper({
+                createStore: (initialState, options) => {
+                    expect(options.isServer).toBe(true);
+                    expect(options.query).toBeDefined();
+                    expect(options.req).toBeDefined();
+                    return createStore((s => s), initialState, applyMiddleware(promiseMiddleware()));
+                }
+            })(App);
+            const component = renderer.create(<WrappedApp store={makeStore({})}/>);
+            await WrappedApp.getInitialProps({
+                req: {},
+                query: {}
+            });
+            expect(component.toJSON()).toMatchSnapshot();
+        });
+    });
+});

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -98,18 +98,3 @@ test('advanced props', () => {
     expect(component.toJSON()).toMatchSnapshot();
 
 });
-
-test('map initial props', () => {
-    const App = ({foo}) => (<div>{foo}</div>);
-    const WrappedApp = wrapper({
-        createStore: makeStore,
-        mapStateToProps: (state) => state,
-        mapInitialProps: (props) => {
-            props.foo = 'bar';
-            return props;
-        }
-    })(App);
-
-    const component = renderer.create(<WrappedApp foo="foo"/>);
-    expect(component.toJSON()).toMatchSnapshot();
-});

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -98,3 +98,18 @@ test('advanced props', () => {
     expect(component.toJSON()).toMatchSnapshot();
 
 });
+
+test('map initial props', () => {
+    const App = ({foo}) => (<div>{foo}</div>);
+    const WrappedApp = wrapper({
+        createStore: makeStore,
+        mapStateToProps: (state) => state,
+        mapInitialProps: (props) => {
+            props.foo = 'bar';
+            return props;
+        }
+    })(App);
+
+    const component = renderer.create(<WrappedApp foo="foo"/>);
+    expect(component.toJSON()).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR should add tests to bring coverage close to 100%. It tests the various new configuration options and also the differences or memoization or not on the client vs server.

![image](https://user-images.githubusercontent.com/46014/28412995-dbb4f1ee-6d3d-11e7-846d-fd9eb0b2523d.png)

I have also made a small fix/tweak to the logic around setting the `debug` flag as discovered when writing the tests