### PR TITLE
Allow users to implement custom logic for serializing and deserializing the redux state.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,12 @@ function initStore(makeStore, initialState, context, config) {
 
 module.exports = function(createStore) {
 
-    var config = {storeKey: DEFAULT_KEY, debug: _debug};
+    var config = {
+        storeKey: DEFAULT_KEY,
+        debug: _debug,
+        serializeState: function(state) { return state; },
+        deserializeState: function(state) { return state; }
+    };
     var connectArgs;
 
     // Ensure backwards compatibility, the config object should come last after connect arguments.
@@ -64,6 +69,14 @@ module.exports = function(createStore) {
 
         if (({}).hasOwnProperty.call(wrappedConfig, 'storeKey')) {
             config.storeKey = wrappedConfig.storeKey;
+        }
+        
+        if (({}).hasOwnProperty.call(wrappedConfig, 'serializeState')) {
+            config.serializeState = wrappedConfig.serializeState;
+        }
+        
+        if (({}).hasOwnProperty.call(wrappedConfig, 'deserializeState')) {
+            config.deserializeState = wrappedConfig.deserializeState;
         }
 
         // Map the connect arguments from the passed in config object.
@@ -92,7 +105,7 @@ module.exports = function(createStore) {
             var hasStore = props.store && props.store.dispatch && props.store.getState;
             var store = hasStore
                 ? props.store
-                : initStore(createStore, initialState, {}, config); // client case, no store but has initialState
+                : initStore(createStore, config.deserializeState(initialState), {}, config); // client case, no store but has initialState
 
             if (!store) {
                 console.error('Attention, withRedux has to be used only for top level pages, all other components must be wrapped with React Redux connect!');
@@ -139,7 +152,7 @@ module.exports = function(createStore) {
                 return {
                     isServer: arr[0],
                     store: arr[1],
-                    initialState: arr[1].getState(),
+                    initialState: config.serializeState(arr[1].getState()),
                     initialProps: arr[3]
                 };
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -165,4 +165,15 @@ describe('createStore', () => {
         renderer.create(<App2 foo="foo"/>);
         expect(window.__NEXT_REDUX_STORE__).toBeDefined();
     });
+    
+    test('usage of custom state deserialization on client', async () => {
+        const App = ({foo}) => (<div>{foo}</div>);
+        const App1 = wrapper({
+            createStore: makeStore,
+            deserializeState: () => ({ deserialized: true })
+        }, state => state)(App);
+        renderer.create(<App1/>);
+        expect(window.__NEXT_REDUX_STORE__.getState).toBeDefined();
+        expect(window.__NEXT_REDUX_STORE__.getState()).toHaveProperty('deserialized', true);
+    });
 });


### PR DESCRIPTION
This PR implements two additional options called `serializeState` and `deserializeState`. The idea is to allow users to implement a custom logic how to serialize the redux state on the server and how to deserialize it on the client.

This comes handy if the user wants to store instances of complex types in the state, using techniques like EJSON (https://github.com/primus/ejson).

Todos:
* [x] Fix tests
* [x] Extend README