### PR TITLE
2.x: Allow users to implement custom logic for serializing and deserializing the redux state.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,13 @@ const initStore = (makeStore, initialState, ctx, config) => {
  */
 export default (createStore, config = {}) => {
 
-    config = {storeKey: DEFAULT_KEY, debug: _debug, ...config};
+    config = {
+        storeKey: DEFAULT_KEY,
+        debug: _debug,
+        serializeState: state => state,
+        deserializeState: state => state,
+        ...config
+    };
 
     return (App) => (class WrappedApp extends BaseApp {
 
@@ -84,7 +90,7 @@ export default (createStore, config = {}) => {
             return {
                 isServer,
                 store,
-                initialState: store.getState(),
+                initialState: config.serializeState(store.getState()),
                 initialProps: initialProps
             };
         };
@@ -95,7 +101,12 @@ export default (createStore, config = {}) => {
 
             const hasStore = store && ('dispatch' in store) && ('getState' in store);
 
-            store = hasStore ? store : initStore(createStore, initialState, {}, config); // client case, no store but has initialState
+            store = hasStore ? store : initStore(
+                createStore,
+                config.deserializeState(initialState),
+                {},
+                config
+            ); // client case, no store but has initialState
 
             if (config.debug) console.log('4. WrappedApp.render', (hasStore ? 'picked up existing one,' : 'created new store with'), 'initialState', initialState);
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -74,3 +74,28 @@ test('async store integration', async () => {
     const WrappedPage = withRedux(makeStore)(AsyncPage);
     await verifyComponent(WrappedPage);
 });
+
+describe('custom serialization', () => {
+    beforeEach(() => {
+        delete window.__NEXT_REDUX_STORE__;
+    });
+    
+    test('custom state serialization on the server', async () => {
+        const WrappedPage = withRedux(makeStore, {
+            serializeState: state => ({ ...state, serialized: true })
+        })(AsyncPage);
+        
+        const props = await WrappedPage.getInitialProps();
+        expect(props.initialState.serialized).toBeTruthy();
+    });
+    
+    test('custom state deserialization on the client', async () => {
+        const WrappedPage = withRedux(makeStore, {
+            deserializeState: state => ({ ...state, deserialized: true })
+        })(AsyncPage);
+        
+        renderer.create(<WrappedPage />);
+        expect(window.__NEXT_REDUX_STORE__.getState().deserialized).toBeTruthy();
+        
+    });
+});


### PR DESCRIPTION
(This PR implements #83 for the upcoming 2.x version.)

This PR implements two additional options called `serializeState` and `deserializeState`. The idea is to allow users to implement a custom logic how to serialize the redux state on the server and how to deserialize it on the client.

This comes handy if the user wants to store instances of complex types in the state, using techniques like EJSON (https://github.com/primus/ejson).
