### PR TITLE
Pass context down to serialize and deserialize

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "npm run lint:staged && npm test:quick"
+    "pre-commit": "npm run lint:staged && npm run test:quick"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "lerna run test --concurrency=1 --stream",
     "test:quick": "lerna run test:quick --concurrency=1 --stream",
     "test:coverage": "cat packages/*/coverage/lcov.info | coveralls",
-    "publish:canary": "lerna publish --canary --force-publish=* --access=public",
+    "publish:canary": "lerna publish --canary --force-publish=*",
     "publish:release": "lerna publish from-package --tag-version-prefix=''",
     "prepare:release": "lerna version --tag-version-prefix='' --force-publish=*",
     "prepare:prerelease": "npm run prepare:release prerelease -- --preid alpha",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "lerna run test --concurrency=1 --stream",
     "test:quick": "lerna run test:quick --concurrency=1 --stream",
     "test:coverage": "cat packages/*/coverage/lcov.info | coveralls",
-    "publish:canary": "lerna publish --canary --force-publish=*",
+    "publish:canary": "lerna publish --canary --force-publish=* --access=public",
     "publish:release": "lerna publish from-package --tag-version-prefix=''",
     "prepare:release": "lerna version --tag-version-prefix='' --force-publish=*",
     "prepare:prerelease": "npm run prepare:release prerelease -- --preid alpha",

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "rimraf": "2.6.3",
     "typescript": "3.5.1"
   },
-  "author": "Kirill Konshin",
+  "author": "NIST GmbH",
   "repository": {
     "type": "git",
-    "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
+    "url": "git://github.com/teamnist/next-redux-wrapper.git"
   },
   "bugs": {
-    "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
+    "url": "https://github.com/teamnist/next-redux-wrapper/issues"
   },
-  "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
+  "homepage": "https://github.com/teamnist/next-redux-wrapper",
   "license": "MIT"
 }

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -41,14 +41,14 @@
     "next": ">=6.0.0",
     "react": "*"
   },
-  "author": "Kirill Konshin",
+  "author": "NIST GmbH",
   "repository": {
     "type": "git",
-    "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
+    "url": "git://github.com/teamnist/next-redux-wrapper.git"
   },
   "bugs": {
-    "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
+    "url": "https://github.com/teamnist/next-redux-wrapper/issues"
   },
-  "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
+  "homepage": "https://github.com/teamnist/next-redux-wrapper",
   "license": "MIT"
 }

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nist-gmbh/next-redux-wrapper",
+  "name": "@teamnist/next-redux-wrapper",
   "version": "3.0.0-alpha.3",
   "description": "Redux wrapper for Next.js",
   "main": "lib/index.js",

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-redux-wrapper",
+  "name": "@nist-gmbh/next-redux-wrapper",
   "version": "3.0.0-alpha.3",
   "description": "Redux wrapper for Next.js",
   "main": "lib/index.js",

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -37,6 +37,9 @@
     "ts-jest": "24.0.2",
     "typescript": "3.5.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "next": ">=6.0.0",
     "react": "*"


### PR DESCRIPTION
# What this PR does
The PR adds the context to the serialize and deserialize functions and introduces a new debug flag to enable and disable printing the state.

# Why
This change offers a simple way to put the serialized state into a cookie for example and to read it from it. Therefore complex solutions like redux-persist can be avoided.