### PR TITLE
add context to serialize and deserialize

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "npm run lint:staged && npm test:quick"
+    "pre-commit": "npm run lint:staged && npm run test:quick"
   }
 }

--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -6,6 +6,7 @@ import {NextAppContext} from 'next/app';
 const defaultConfig: Config = {
     storeKey: '__NEXT_REDUX_STORE__',
     debug: false,
+    printState: false,
     serializeState: state => state,
     deserializeState: state => state,
 };
@@ -56,7 +57,10 @@ export default (makeStore: MakeStore, config?: Config) => {
                 });
 
                 if (config.debug)
-                    console.log('1. WrappedApp.getInitialProps wrapper got the store with state', store.getState());
+                    console.log(
+                        '1. WrappedApp.getInitialProps wrapper got the store with state',
+                        config.printState ? store.getState() : {},
+                    );
 
                 appCtx.ctx.store = store;
 
@@ -66,7 +70,11 @@ export default (makeStore: MakeStore, config?: Config) => {
                     initialProps = await App.getInitialProps.call(App, appCtx);
                 }
 
-                if (config.debug) console.log('3. WrappedApp.getInitialProps has store state', store.getState());
+                if (config.debug)
+                    console.log(
+                        '3. WrappedApp.getInitialProps has store state',
+                        config.printState ? store.getState() : {},
+                    );
 
                 return {
                     isServer,
@@ -80,7 +88,11 @@ export default (makeStore: MakeStore, config?: Config) => {
 
                 const {initialState} = props;
 
-                if (config.debug) console.log('4. WrappedApp.render created new store with initialState', initialState);
+                if (config.debug)
+                    console.log(
+                        '4. WrappedApp.render created new store with initialState',
+                        config.printState ? initialState : {},
+                    );
 
                 this.store = initStore({
                     initialState,
@@ -103,6 +115,7 @@ export interface Config {
     deserializeState?: (any, NextJSContext) => any;
     storeKey?: string;
     debug?: boolean;
+    printState?: boolean;
     overrideIsServer?: boolean;
 }
 

--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -22,7 +22,7 @@ export default (makeStore: MakeStore, config?: Config) => {
         const {storeKey} = config;
 
         const createStore = () =>
-            makeStore(config.deserializeState(initialState), {
+            makeStore(config.deserializeState(initialState, ctx), {
                 ...ctx,
                 ...config,
                 isServer,
@@ -49,6 +49,8 @@ export default (makeStore: MakeStore, config?: Config) => {
                 /* istanbul ignore next */
                 if (!appCtx.ctx) throw new Error('No page context');
 
+                appCtx.ctx.isServer = isServer;
+
                 const store = initStore({
                     ctx: appCtx.ctx,
                 });
@@ -57,7 +59,6 @@ export default (makeStore: MakeStore, config?: Config) => {
                     console.log('1. WrappedApp.getInitialProps wrapper got the store with state', store.getState());
 
                 appCtx.ctx.store = store;
-                appCtx.ctx.isServer = isServer;
 
                 let initialProps = {};
 
@@ -69,7 +70,7 @@ export default (makeStore: MakeStore, config?: Config) => {
 
                 return {
                     isServer,
-                    initialState: config.serializeState(store.getState()),
+                    initialState: config.serializeState(store.getState(), appCtx.ctx),
                     initialProps,
                 };
             };
@@ -98,8 +99,8 @@ export default (makeStore: MakeStore, config?: Config) => {
 };
 
 export interface Config {
-    serializeState?: (any) => any;
-    deserializeState?: (any) => any;
+    serializeState?: (any, NextJSContext) => any;
+    deserializeState?: (any, NextJSContext) => any;
     storeKey?: string;
     debug?: boolean;
     overrideIsServer?: boolean;


### PR DESCRIPTION
### What this PR does

The PR adds the context to the serialize and deserialize functions and introduces a new debug flag to enable and disable printing the state.

### Why

This change offers a simple way to put the serialized state into a cookie for example and to read it from it. Therefore complex solutions like redux-persist can be avoided.