### PR TITLE
Add generics to NextJSContext

### DIFF
--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {Store} from 'redux';
+import {Store, AnyAction, Action} from 'redux';
 import {NextComponentType, NextContext} from 'next';
 import {NextAppContext} from 'next/app';
 
@@ -105,8 +105,8 @@ export interface Config {
     overrideIsServer?: boolean;
 }
 
-export interface NextJSContext extends NextContext {
-    store: Store;
+export interface NextJSContext<S = any, A extends Action = AnyAction> extends NextContext {
+    store: Store<S, A>;
     isServer: boolean;
 }
 


### PR DESCRIPTION
Hi. Thank you for your awesome library.
I am greatly helped by this library for using next + redux + typescript.

Now I write `getInitialProps` with `NextJSContext` and use `store`'s state value.
But type of store is `any` because it dosen't know type of state and actions.

![screenhost 2019-07-24 13 07 44](https://user-images.githubusercontent.com/1858949/61764413-123bd200-ae14-11e9-84f6-0425f5eed3f3.png)

So, I add generics to `NextJSContext` based on `Store` of `redux`.
It is not breaking change because these generics have default type.

https://github.com/reduxjs/redux/blob/master/index.d.ts#L160-L168

![screenshot 2019-07-24 13 56 26](https://user-images.githubusercontent.com/1858949/61766185-ee2fbf00-ae1a-11e9-9a25-ed7588f80b1b.png)

Thanks.
