### PR TITLE
Nextjs 9 Typescript changes

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "npm run lint:staged && npm test:quick"
+    "pre-commit": "npm run lint:staged && npm run test:quick"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,4 @@
 {
-  "packages": [
-    "packages/*"
-  ],
-  "version": "3.0.0-alpha.3"
+    "packages": ["packages/*"],
+    "version": "3.0.0-alpha.4"
 }

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-redux-wrapper-configs",
-  "private": true,
-  "version": "3.0.0-alpha.3"
+    "name": "next-redux-wrapper-configs",
+    "private": true,
+    "version": "3.0.0-alpha.4"
 }

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "next-redux-wrapper-configs",
-    "private": true,
-    "version": "3.0.0-alpha.4"
+  "name": "next-redux-wrapper-configs",
+  "private": true,
+  "version": "3.0.0-alpha.4"
 }

--- a/packages/demo/.babelrc
+++ b/packages/demo/.babelrc
@@ -1,6 +1,3 @@
 {
-  "presets": [
-    "next/babel",
-    "@zeit/next-typescript/babel"
-  ]
+    "presets": ["next/babel"]
 }

--- a/packages/demo/jest-puppeteer.config.js
+++ b/packages/demo/jest-puppeteer.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     server: {
-        command: 'npm start',
+        command: 'npm run serve',
         debug: true,
         port: 3000,
         launchTimeout: 30000,

--- a/packages/demo/next-env.d.ts
+++ b/packages/demo/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/packages/demo/next.config.js
+++ b/packages/demo/next.config.js
@@ -1,2 +1,1 @@
-const withTypescript = require('@zeit/next-typescript');
-module.exports = withTypescript();
+module.exports = {};

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,49 +1,47 @@
 {
-  "name": "next-redux-wrapper-demo",
-  "private": true,
-  "version": "3.0.0-alpha.3",
-  "description": "Demo of redux wrapper for Next.js",
-  "scripts": {
-    "clean": "rimraf .next coverage",
-    "test": "jest --runInBand",
-    "start": "next",
-    "build": "next build",
-    "serve": "next start"
-  },
-  "dependencies": {
-    "next-redux-wrapper": "^3.0.0-alpha.3",
-    "react": "16.8.6",
-    "react-dom": "16.8.6",
-    "react-redux": "7.0.3",
-    "redux": "4.0.1"
-  },
-  "devDependencies": {
-    "@types/expect-puppeteer": "3.3.1",
-    "@types/jest": "24.0.13",
-    "@types/jest-environment-puppeteer": "4.0.0",
-    "@types/next": "8.0.5",
-    "@types/puppeteer": "1.12.4",
-    "@types/react": "16.8.19",
-    "@types/react-redux": "7.0.9",
-    "@types/redux-promise-middleware": "0.0.11",
-    "@types/webpack-env": "1.13.9",
-    "@zeit/next-typescript": "1.1.1",
-    "jest-puppeteer": "4.2.0",
-    "next": "8.1.0",
-    "next-redux-wrapper-configs": "^3.0.0-alpha.3",
-    "puppeteer": "1.17.0",
-    "rimraf": "2.6.3",
-    "ts-jest": "24.0.2",
-    "typescript": "3.5.1"
-  },
-  "author": "Kirill Konshin",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
-  },
-  "bugs": {
-    "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
-  },
-  "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
-  "license": "MIT"
+    "name": "next-redux-wrapper-demo",
+    "private": true,
+    "version": "3.0.0-alpha.3",
+    "description": "Demo of redux wrapper for Next.js",
+    "scripts": {
+        "clean": "rimraf .next coverage",
+        "test": "jest --runInBand",
+        "start": "next",
+        "build": "next build",
+        "serve": "next start"
+    },
+    "dependencies": {
+        "next-redux-wrapper": "^3.0.0-alpha.3",
+        "react": "16.8.6",
+        "react-dom": "16.8.6",
+        "react-redux": "7.0.3",
+        "redux": "4.0.1"
+    },
+    "devDependencies": {
+        "@types/expect-puppeteer": "3.3.1",
+        "@types/jest": "24.0.13",
+        "@types/jest-environment-puppeteer": "4.0.0",
+        "@types/puppeteer": "1.12.4",
+        "@types/react": "16.8.19",
+        "@types/react-redux": "7.0.9",
+        "@types/redux-promise-middleware": "0.0.11",
+        "@types/webpack-env": "1.13.9",
+        "jest-puppeteer": "4.2.0",
+        "next": "9.0.3",
+        "next-redux-wrapper-configs": "^3.0.0-alpha.3",
+        "puppeteer": "1.17.0",
+        "rimraf": "2.6.3",
+        "ts-jest": "24.0.2",
+        "typescript": "3.5.1"
+    },
+    "author": "Kirill Konshin",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
+    },
+    "bugs": {
+        "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
+    },
+    "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
+    "license": "MIT"
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,48 +1,48 @@
 {
-    "name": "next-redux-wrapper-demo",
-    "private": true,
-    "version": "3.0.0-alpha.4",
-    "description": "Demo of redux wrapper for Next.js",
-    "scripts": {
-        "clean": "rimraf .next coverage",
-        "test": "jest --runInBand",
-        "start": "next",
-        "build": "next build",
-        "serve": "next start"
-    },
-    "dependencies": {
-        "next-redux-wrapper": "^3.0.0-alpha.4",
-        "react": "16.8.6",
-        "react-dom": "16.8.6",
-        "react-redux": "7.0.3",
-        "redux": "4.0.1"
-    },
-    "devDependencies": {
-        "@types/expect-puppeteer": "3.3.1",
-        "@types/jest": "24.0.13",
-        "@types/jest-environment-puppeteer": "4.0.0",
-        "@types/puppeteer": "1.12.4",
-        "@types/react": "16.8.19",
-        "@types/react-dom": "16.9.0",
-        "@types/react-redux": "7.0.9",
-        "@types/redux-promise-middleware": "0.0.11",
-        "@types/webpack-env": "1.13.9",
-        "jest-puppeteer": "4.2.0",
-        "next": "9.0.3",
-        "next-redux-wrapper-configs": "^3.0.0-alpha.4",
-        "puppeteer": "1.17.0",
-        "rimraf": "2.6.3",
-        "ts-jest": "24.0.2",
-        "typescript": "3.5.1"
-    },
-    "author": "Kirill Konshin",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
-    },
-    "bugs": {
-        "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
-    },
-    "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
-    "license": "MIT"
+  "name": "next-redux-wrapper-demo",
+  "private": true,
+  "version": "3.0.0-alpha.4",
+  "description": "Demo of redux wrapper for Next.js",
+  "scripts": {
+    "clean": "rimraf .next coverage",
+    "test": "jest --runInBand",
+    "start": "next",
+    "build": "next build",
+    "serve": "next start"
+  },
+  "dependencies": {
+    "next-redux-wrapper": "^3.0.0-alpha.4",
+    "react": "16.8.6",
+    "react-dom": "16.8.6",
+    "react-redux": "7.0.3",
+    "redux": "4.0.1"
+  },
+  "devDependencies": {
+    "@types/expect-puppeteer": "3.3.1",
+    "@types/jest": "24.0.13",
+    "@types/jest-environment-puppeteer": "4.0.0",
+    "@types/puppeteer": "1.12.4",
+    "@types/react": "16.8.19",
+    "@types/react-dom": "16.9.0",
+    "@types/react-redux": "7.0.9",
+    "@types/redux-promise-middleware": "0.0.11",
+    "@types/webpack-env": "1.13.9",
+    "jest-puppeteer": "4.2.0",
+    "next": "9.0.3",
+    "next-redux-wrapper-configs": "^3.0.0-alpha.4",
+    "puppeteer": "1.17.0",
+    "rimraf": "2.6.3",
+    "ts-jest": "24.0.2",
+    "typescript": "3.5.1"
+  },
+  "author": "Kirill Konshin",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
+  },
+  "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
+  "license": "MIT"
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,7 +1,7 @@
 {
     "name": "next-redux-wrapper-demo",
     "private": true,
-    "version": "3.0.0-alpha.3",
+    "version": "3.0.0-alpha.4",
     "description": "Demo of redux wrapper for Next.js",
     "scripts": {
         "clean": "rimraf .next coverage",
@@ -11,7 +11,7 @@
         "serve": "next start"
     },
     "dependencies": {
-        "next-redux-wrapper": "^3.0.0-alpha.3",
+        "next-redux-wrapper": "^3.0.0-alpha.4",
         "react": "16.8.6",
         "react-dom": "16.8.6",
         "react-redux": "7.0.3",
@@ -23,12 +23,13 @@
         "@types/jest-environment-puppeteer": "4.0.0",
         "@types/puppeteer": "1.12.4",
         "@types/react": "16.8.19",
+        "@types/react-dom": "16.9.0",
         "@types/react-redux": "7.0.9",
         "@types/redux-promise-middleware": "0.0.11",
         "@types/webpack-env": "1.13.9",
         "jest-puppeteer": "4.2.0",
         "next": "9.0.3",
-        "next-redux-wrapper-configs": "^3.0.0-alpha.3",
+        "next-redux-wrapper-configs": "^3.0.0-alpha.4",
         "puppeteer": "1.17.0",
         "rimraf": "2.6.3",
         "ts-jest": "24.0.2",

--- a/packages/demo/tests/index.test.ts
+++ b/packages/demo/tests/index.test.ts
@@ -1,4 +1,4 @@
-const config = require('../jest-puppeteer.config');
+import config from '../jest-puppeteer.config';
 
 const openPage = (url = '/') => page.goto(`http://localhost:${config.server.port}${url}`);
 

--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -4,5 +4,18 @@
     "tests",
     "pages",
     "components"
+  ],
+  "compilerOptions": {
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "exclude": [
+    "node_modules"
   ]
 }

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,53 +1,53 @@
 {
-    "name": "next-redux-wrapper",
-    "version": "3.0.0-alpha.4",
-    "description": "Redux wrapper for Next.js",
-    "main": "lib/index.js",
-    "module": "es6/index.js",
-    "types": "es6/index.d.ts",
-    "source": "lib/index.ts",
-    "scripts": {
-        "test": "jest",
-        "test:quick": "npm run test",
-        "clean": "rimraf lib es6 types coverage",
-        "build": "npm run clean && npm run build:tsc:es5 && npm run build:tsc:es6",
-        "build:tsc:es5": "tsc",
-        "build:tsc:es6": "tsc --project tsconfig.es6.json",
-        "start": "npm-run-all -p start:tsc:es5 start:tsc:es6",
-        "start:tsc:es5": "npm run build:tsc:es5 -- --watch --preserveWatchOutput",
-        "start:tsc:es6": "npm run build:tsc:es6 -- --watch --preserveWatchOutput"
-    },
-    "devDependencies": {
-        "@types/jest": "24.0.13",
-        "@types/react": "16.8.19",
-        "@types/react-redux": "7.0.9",
-        "@types/redux-promise-middleware": "0.0.11",
-        "jest": "24.8.0",
-        "next": "9.0.3",
-        "next-redux-wrapper-configs": "^3.0.0-alpha.4",
-        "npm-run-all": "4.1.5",
-        "react": "16.8.6",
-        "react-dom": "16.8.6",
-        "react-redux": "7.0.3",
-        "react-test-renderer": "16.8.6",
-        "redux": "4.0.1",
-        "redux-promise-middleware": "6.1.0",
-        "rimraf": "2.6.3",
-        "ts-jest": "24.0.2",
-        "typescript": "3.5.1"
-    },
-    "peerDependencies": {
-        "next": ">=9.0.0",
-        "react": "*"
-    },
-    "author": "Kirill Konshin",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
-    },
-    "bugs": {
-        "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
-    },
-    "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
-    "license": "MIT"
+  "name": "next-redux-wrapper",
+  "version": "3.0.0-alpha.4",
+  "description": "Redux wrapper for Next.js",
+  "main": "lib/index.js",
+  "module": "es6/index.js",
+  "types": "es6/index.d.ts",
+  "source": "lib/index.ts",
+  "scripts": {
+    "test": "jest",
+    "test:quick": "npm run test",
+    "clean": "rimraf lib es6 types coverage",
+    "build": "npm run clean && npm run build:tsc:es5 && npm run build:tsc:es6",
+    "build:tsc:es5": "tsc",
+    "build:tsc:es6": "tsc --project tsconfig.es6.json",
+    "start": "npm-run-all -p start:tsc:es5 start:tsc:es6",
+    "start:tsc:es5": "npm run build:tsc:es5 -- --watch --preserveWatchOutput",
+    "start:tsc:es6": "npm run build:tsc:es6 -- --watch --preserveWatchOutput"
+  },
+  "devDependencies": {
+    "@types/jest": "24.0.13",
+    "@types/react": "16.8.19",
+    "@types/react-redux": "7.0.9",
+    "@types/redux-promise-middleware": "0.0.11",
+    "jest": "24.8.0",
+    "next": "9.0.3",
+    "next-redux-wrapper-configs": "^3.0.0-alpha.4",
+    "npm-run-all": "4.1.5",
+    "react": "16.8.6",
+    "react-dom": "16.8.6",
+    "react-redux": "7.0.3",
+    "react-test-renderer": "16.8.6",
+    "redux": "4.0.1",
+    "redux-promise-middleware": "6.1.0",
+    "rimraf": "2.6.3",
+    "ts-jest": "24.0.2",
+    "typescript": "3.5.1"
+  },
+  "peerDependencies": {
+    "next": ">=9.0.0",
+    "react": "*"
+  },
+  "author": "Kirill Konshin",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
+  },
+  "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
+  "license": "MIT"
 }

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "next-redux-wrapper",
-    "version": "3.0.0-alpha.3",
+    "version": "3.0.0-alpha.4",
     "description": "Redux wrapper for Next.js",
     "main": "lib/index.js",
     "module": "es6/index.js",
@@ -24,7 +24,7 @@
         "@types/redux-promise-middleware": "0.0.11",
         "jest": "24.8.0",
         "next": "9.0.3",
-        "next-redux-wrapper-configs": "^3.0.0-alpha.3",
+        "next-redux-wrapper-configs": "^3.0.0-alpha.4",
         "npm-run-all": "4.1.5",
         "react": "16.8.6",
         "react-dom": "16.8.6",
@@ -37,7 +37,7 @@
         "typescript": "3.5.1"
     },
     "peerDependencies": {
-        "next": ">=6.0.0",
+        "next": ">=9.0.0",
         "react": "*"
     },
     "author": "Kirill Konshin",

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,54 +1,53 @@
 {
-  "name": "next-redux-wrapper",
-  "version": "3.0.0-alpha.3",
-  "description": "Redux wrapper for Next.js",
-  "main": "lib/index.js",
-  "module": "es6/index.js",
-  "types": "es6/index.d.ts",
-  "source": "lib/index.ts",
-  "scripts": {
-    "test": "jest",
-    "test:quick": "npm run test",
-    "clean": "rimraf lib es6 types coverage",
-    "build": "npm run clean && npm run build:tsc:es5 && npm run build:tsc:es6",
-    "build:tsc:es5": "tsc",
-    "build:tsc:es6": "tsc --project tsconfig.es6.json",
-    "start": "npm-run-all -p start:tsc:es5 start:tsc:es6",
-    "start:tsc:es5": "npm run build:tsc:es5 -- --watch --preserveWatchOutput",
-    "start:tsc:es6": "npm run build:tsc:es6 -- --watch --preserveWatchOutput"
-  },
-  "devDependencies": {
-    "@types/jest": "24.0.13",
-    "@types/next": "8.0.5",
-    "@types/react": "16.8.19",
-    "@types/react-redux": "7.0.9",
-    "@types/redux-promise-middleware": "0.0.11",
-    "@zeit/next-typescript": "1.1.1",
-    "jest": "24.8.0",
-    "next-redux-wrapper-configs": "^3.0.0-alpha.3",
-    "npm-run-all": "4.1.5",
-    "react": "16.8.6",
-    "react-dom": "16.8.6",
-    "react-redux": "7.0.3",
-    "react-test-renderer": "16.8.6",
-    "redux": "4.0.1",
-    "redux-promise-middleware": "6.1.0",
-    "rimraf": "2.6.3",
-    "ts-jest": "24.0.2",
-    "typescript": "3.5.1"
-  },
-  "peerDependencies": {
-    "next": ">=6.0.0",
-    "react": "*"
-  },
-  "author": "Kirill Konshin",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
-  },
-  "bugs": {
-    "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
-  },
-  "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
-  "license": "MIT"
+    "name": "next-redux-wrapper",
+    "version": "3.0.0-alpha.3",
+    "description": "Redux wrapper for Next.js",
+    "main": "lib/index.js",
+    "module": "es6/index.js",
+    "types": "es6/index.d.ts",
+    "source": "lib/index.ts",
+    "scripts": {
+        "test": "jest",
+        "test:quick": "npm run test",
+        "clean": "rimraf lib es6 types coverage",
+        "build": "npm run clean && npm run build:tsc:es5 && npm run build:tsc:es6",
+        "build:tsc:es5": "tsc",
+        "build:tsc:es6": "tsc --project tsconfig.es6.json",
+        "start": "npm-run-all -p start:tsc:es5 start:tsc:es6",
+        "start:tsc:es5": "npm run build:tsc:es5 -- --watch --preserveWatchOutput",
+        "start:tsc:es6": "npm run build:tsc:es6 -- --watch --preserveWatchOutput"
+    },
+    "devDependencies": {
+        "@types/jest": "24.0.13",
+        "@types/react": "16.8.19",
+        "@types/react-redux": "7.0.9",
+        "@types/redux-promise-middleware": "0.0.11",
+        "jest": "24.8.0",
+        "next": "9.0.3",
+        "next-redux-wrapper-configs": "^3.0.0-alpha.3",
+        "npm-run-all": "4.1.5",
+        "react": "16.8.6",
+        "react-dom": "16.8.6",
+        "react-redux": "7.0.3",
+        "react-test-renderer": "16.8.6",
+        "redux": "4.0.1",
+        "redux-promise-middleware": "6.1.0",
+        "rimraf": "2.6.3",
+        "ts-jest": "24.0.2",
+        "typescript": "3.5.1"
+    },
+    "peerDependencies": {
+        "next": ">=6.0.0",
+        "react": "*"
+    },
+    "author": "Kirill Konshin",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/kirill-konshin/next-redux-wrapper.git"
+    },
+    "bugs": {
+        "url": "https://github.com/kirill-konshin/next-redux-wrapper/issues"
+    },
+    "homepage": "https://github.com/kirill-konshin/next-redux-wrapper",
+    "license": "MIT"
 }

--- a/packages/wrapper/src/index.spec.tsx
+++ b/packages/wrapper/src/index.spec.tsx
@@ -2,14 +2,14 @@ import React, {Component} from 'react';
 import {applyMiddleware, createStore} from 'redux';
 import promiseMiddleware from 'redux-promise-middleware';
 import renderer from 'react-test-renderer';
-import {NextAppContext} from 'next/app';
 import withRedux from '../src/index';
+import {AppContext} from 'next/app';
 
-interface NextAppContextTest extends NextAppContext {
+interface NextAppContextTest extends AppContext {
     ctx: any;
 }
 
-const appCtx: NextAppContextTest = {ctx: {}, Component: null, router: null};
+const appCtx: NextAppContextTest = {ctx: {}, Component: null, router: null, AppTree: () => null};
 
 const reducer = (state = {reduxStatus: 'init'}, action) => {
     switch (action.type) {

--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {Store, AnyAction, Action} from 'redux';
-import {NextComponentType, NextContext} from 'next';
-import {NextAppContext} from 'next/app';
+import {NextComponentType, NextPageContext} from 'next';
+import {AppContext} from 'next/app';
 
 const defaultConfig: Config = {
     storeKey: '__NEXT_REDUX_STORE__',
@@ -105,12 +105,12 @@ export interface Config {
     overrideIsServer?: boolean;
 }
 
-export interface NextJSContext<S = any, A extends Action = AnyAction> extends NextContext {
+export interface NextJSContext<S = any, A extends Action = AnyAction> extends NextPageContext {
     store: Store<S, A>;
     isServer: boolean;
 }
 
-export interface NextJSAppContext extends NextAppContext {
+export interface NextJSAppContext extends AppContext {
     ctx: NextJSContext;
 }
 


### PR DESCRIPTION
Using nextjs9 with the current version just break the typings experience. This is just a initial commit to up the version. @kirill-konshin please feel free to edit the PR to move forwards with nextjs 9 typings. This could break those that are still in less than nextjs 9.0.