### PR TITLE
Revise Readme (fixes #170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,43 @@
-Redux wrapper for Next.js
-=========================
+# Redux Wrapper for Next.js  <!-- omit in toc -->
 
+[![npm version](https://badge.fury.io/js/next-redux-wrapper.svg)](https://www.npmjs.com/package/next-redux-wrapper)
 ![Build status](https://travis-ci.org/kirill-konshin/next-redux-wrapper.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/kirill-konshin/next-redux-wrapper/badge.svg?branch=master)](https://coveralls.io/github/kirill-konshin/next-redux-wrapper?branch=master)
 
-:warning: Version 4 of this library will work only with Next.js 9. If you're using Next.js 6-8 you can use previous versions. :warning:
 
-Next.js 5 (for individual pages) is compatible only with [1.x branch](https://github.com/kirill-konshin/next-redux-wrapper/tree/1.x) or you can follow these simple [upgrade instructions](#upgrade).
+A HOC that brings Next.js and Redux together
 
-This library is compatible with NextJS 9, but it is not compatible with [NextJS 9's Auto Partial Static Export](https://nextjs.org/blog/next-9#automatic-partial-static-export) feature, see [explanation below](#automatic-partial-static-export).
+:warning: The current version of this library only works with Next.js 9. If you are required to use Next.js 6-8 you can use version 3 of this library. Otherwise, consider upgrading Next.js. :warning:
 
+Next.js 5 (for individual pages) is only compatible with the [1.x branch](https://github.com/kirill-konshin/next-redux-wrapper/tree/1.x). You can upgrade it following these simple [instructions](#upgrade).
+
+This library is not compatible with [Next.js 9's Auto Partial Static Export](https://nextjs.org/blog/next-9#automatic-partial-static-export) feature, see the [explanation below](#automatic-partial-static-export).
+
+Contents:
+
+- [Motivation](#motivation)
 - [Installation](#installation)
 - [How it works](#how-it-works)
-- [Document](#document)
-- [Error Pages](#error-pages)
-- [Use with layout](#use-with-layout)
-- [Async actions in `getInitialProps`](#async-actions-in-getinitialprops)
-- [Custom serialization and deserialization, usage with Immutable.JS](#custom-serialization-and-deserialization)
-- [Usage with Redux Saga](#usage-with-redux-saga)
-- [Usage with Redux Persist](#usage-with-redux-persist)
-- [Upgrade from 1.x](#upgrade)
+- [Configuration](#configuration)
+- [Tips and Tricks](#tips-and-tricks)
+  - [Document](#document)
+  - [Error Pages](#error-pages)
+  - [Use with layout](#use-with-layout)
+  - [Async actions in `getInitialProps`](#async-actions-in-getinitialprops)
+  - [Custom serialization and deserialization](#custom-serialization-and-deserialization)
+  - [Usage with Redux Saga](#usage-with-redux-saga)
+  - [Usage with Redux Persist](#usage-with-redux-persist)
+- [Automatic Partial Static Export](#automatic-partial-static-export)
+- [Upgrade from 1.x](#upgrade-from-1x)
 - [Resources](#resources)
+
+## Motivation
+
+Setting up Redux for statically rendered Next.js apps is rather simple: A single Redux store has to be created that is provided to all pages (you won't need this package then).
+When SSR is involved, however, things start to get complicated as another store instance is needed on the server to render Redux-connected components.
+Furthermore, access to the Redux store may also be needed during a page's `getInitialProps`.
+
+This is where `next-redux-wrapper` comes in handy: It automatically creates the store instances for you and makes sure they all have the same state.
 
 ## Installation
 
@@ -28,13 +45,15 @@ This library is compatible with NextJS 9, but it is not compatible with [NextJS 
 npm install next-redux-wrapper --save
 ```
 
-Wrapper has to be attached to your `_app` component (located in `/pages`). All other pages may use the regular `connect`
-function of `react-redux`.
+The wrapper has to be attached to your `_app` component (located in `/pages`). All other components can use the `connect` function of `react-redux`.
 
-Here is the minimal setup (`makeStore` and `reducer` usually are located in other files):
+Here is a minimal setup (`makeStore` and `reducer` are usually located in separate files):
 
-```js
-// pages/_app.js
+<details>
+    <summary>JavaScript</summary>
+
+```jsx
+// pages/_app.jsx
 import React from "react";
 import {createStore} from "redux";
 import {Provider} from "react-redux";
@@ -51,28 +70,25 @@ const reducer = (state = {foo: ''}, action) => {
 };
 
 /**
-* @param {object} initialState
-* @param {boolean} options.isServer indicates whether it is a server side or client side
-* @param {Request} options.req NodeJS Request object (not set when client applies initialState from server)
-* @param {Request} options.res NodeJS Request object (not set when client applies initialState from server)
-* @param {boolean} options.debug User-defined debug mode param
-* @param {string} options.storeKey This key will be used to preserve store in global namespace for safe HMR 
+* @param {object} initialState The store's initial state (on the client side, the state of the server-side store is passed here)
+* @param {boolean} options.isServer Indicates whether makeStore is executed on the server or the client side
+* @param {Request} options.req Node.js `Request` object (only set before `getInitialProps` on the server side)
+* @param {Response} options.res Node.js `Response` object (only set before `getInitialProps` on the server side)
+* @param {boolean} options.debug User-defined debug flag
+* @param {string} options.storeKey The key that will be used to persist the store in the browser's `window` object for safe HMR
 */
 const makeStore = (initialState, options) => {
     return createStore(reducer, initialState);
 };
 
 class MyApp extends App {
-
     static async getInitialProps({Component, ctx}) {
-
-        // we can dispatch from here too
+        // We can dispatch from here too
         ctx.store.dispatch({type: 'FOO', payload: 'foo'});
 
         const pageProps = Component.getInitialProps ? await Component.getInitialProps(ctx) : {};
 
         return {pageProps};
-
     }
 
     render() {
@@ -83,96 +99,184 @@ class MyApp extends App {
             </Provider>
         );
     }
-
 }
 
 export default withRedux(makeStore)(MyApp);
 ```
+</details>
 
-> **NOTE**: For versions of NextJS < 9.04, you will need to wrap the `Provider` with `Container` from `next/app`.
-> Thus, the import statement will be:
-> ```js
-> import App, {Container} from "next/app";
-> ```
-> And wrapping the `Provider` will be:
-> ```js
-> return (
->     <Container>
->         <Provider store={store}>
->             <Component {...pageProps} />
->         </Provider>
->     </Container>
-> );
-> ```
+<details>
+    <summary>TypeScript</summary>
 
-And then actual page components can be simply connected:
+```tsx
+// pages/_app.tsx
+import * as React from "react";
+import {createStore} from "redux";
+import {Provider} from "react-redux";
+import App, {AppContext} from 'next/app';
+import withRedux, {ReduxWrapperAppProps, MakeStore} from 'next-redux-wrapper';
 
-```js
-import React, {Component} from "react";
+interface State {
+    foo: string
+}
+
+const reducer = (state: State = {foo: ''}, action) => {
+    switch (action.type) {
+        case 'FOO':
+            return {...state, foo: action.payload};
+        default:
+            return state
+    }
+};
+
+/**
+* @param initialState The store's initial state (on the client side, the state of the server-side store is passed here)
+*/
+const makeStore: MakeStore = (initialState, options) => {
+    return createStore(reducer, initialState);
+};
+
+class MyApp extends App<ReduxWrapperAppProps<State>> {
+    static async getInitialProps({Component, ctx}: AppContext) {
+        // We can dispatch from here too
+        ctx.store.dispatch({type: 'FOO', payload: 'foo'});
+
+        const pageProps = Component.getInitialProps ? await Component.getInitialProps(ctx) : {};
+
+        return {pageProps};
+    }
+
+    render() {
+        const {Component, pageProps, store} = this.props;
+        return (
+            <Provider store={store}>
+                <Component {...pageProps} />
+            </Provider>
+        );
+    }
+}
+
+export default withRedux(makeStore)(MyApp);
+```
+</details>
+
+And then components can simply be connected (the example considers page components):
+
+<details>
+    <summary>JavaScript</summary>
+
+```jsx
+import React from "react";
 import {connect} from "react-redux";
 
-class Page extends Component {
-    static getInitialProps({store, isServer, pathname, query}) {
-        store.dispatch({type: 'FOO', payload: 'foo'}); // component will be able to read from store's state when rendered
-        return {custom: 'custom'}; // you can pass some custom props to component from here
-    }
-    render() {
-        return (
-            <div>
-                <div>Prop from Redux {this.props.foo}</div>
-                <div>Prop from getInitialProps {this.props.custom}</div>
-            </div>
-        )
-    }
+const Page = props => (
+    <div>
+        <div>Prop from Redux {props.foo}</div>
+        <div>Prop from getInitialProps {props.custom}</div>
+    </div>
+);
+
+Page.getInitialProps = ({store, isServer, pathname, query}) => {
+    store.dispatch({type: 'FOO', payload: 'foo'}); // The component can read from the store's state when rendered
+    return {custom: 'custom'}; // You can pass some custom props to the component from here
 }
 
 export default connect(state => state)(Page);
 ```
+</details>
+
+<details>
+    <summary>TypeScript</summary>
+
+```tsx
+import * as React from "react";
+import {connect, ConnectedProps} from "react-redux";
+import {NextPage} from "next";
+import State from "wherever/your-state-type/is-located";
+
+type Props = ConnectedProps<typeof connectToRedux>;
+
+const Page: NextPage<Props, {custom: string}> = props => (
+    <div>
+        <div>Prop from Redux {props.foo}</div>
+        <div>Prop from getInitialProps {props.custom}</div>
+    </div>
+);
+
+Page.getInitialProps = ({store, isServer, pathname, query}) => {
+    store.dispatch({type: 'FOO', payload: 'foo'}); // The component can read from the store's state when rendered
+    return {custom: 'custom'}; // You can pass some custom props to the component from here
+}
+
+const connectToRedux = connect(state: State => state);
+
+export default connectToRedux(Page);
+```
+</details>
+
 
 ## How it works
 
-No magic is involved. It auto-creates the Redux store when `getInitialProps` is called by Next.js and then passes this store
-down to React Redux's `Provider`, which is used to wrap the original component (also automatically). On the client side
-it also takes care of using the same store every time, whereas on the server a new store is created for each request.
+Using `next-redux-wrapper` ("the wrapper"), the following things happen on a request:
 
-The `withRedux` function accepts `makeStore` as its first argument. The `makeStore` function will receive initial state and
-should return a new instance of Redux `store` each time it's called. No memoization is needed here, it is automatically done
-inside the wrapper.
+* Phase 1: `getInitialProps`
+  * The wrapper creates a server-side store (using `makeStore`) with an empty initial state. In doing so it also provides the `Request` and `Response` objects as options to `makeStore`.
+  * The wrapper calls the `_app`'s `getInitialProps` function and passes the previously created store.
+  * Next.js takes the props returned from the `_app`'s `getInitialProps` method, along with the store's state.
 
-`withRedux` also optionally accepts a config object as a second paramter:
+* Phase 2: SSR
+  * The wrapper creates a new store providing the previous store's state as `initialState` to `makeStore`. That store is passed as a property to the `_app` component.
+  * Connected components may alter the store's state, but the modified state will not be transferred to the client.
+
+* Phase 3: Client
+  * The wrapper uses the state from Phase 1 to create a new store, which is again provided to the `_app` component.
+  * The wrapper persists the store in the client's window object, so it can be restored in case of HMR.
+
+**Note:** The client's state is not persisted across requests (i.e. Phase 1 always starts with an empty state).
+Hence, it is reset on page reloads.
+Consider using [Redux persist](#usage-with-redux-persist) if you want to persist state between requests.
+
+## Configuration
+
+The `withRedux` function accepts `makeStore` as its first argument. The `makeStore` function will receive the initial state and
+should return a new Redux `store` instance each time it's called. No memoization is needed here, it is automatically done inside the wrapper.
+
+`withRedux` also optionally accepts a config object as a second parameter:
 
 - `storeKey` (optional, string) : the key used on `window` to persist the store on the client
 - `debug` (optional, boolean) : enable debug logging
 - `serializeState` and `deserializeState`: custom functions for serializing and deserializing the redux state, see
     [Custom serialization and deserialization](#custom-serialization-and-deserialization).
 
-When `makeStore` is invoked it is provided with a configuration object along with NextJS page context which includes:
+When `makeStore` is invoked it is provided with a configuration object along with a Next.js page context which includes:
 
-- `isServer` (boolean): `true` if called while on the server rather than the client
-- `req` (Request): The `next.js` `getInitialProps` context `req` parameter
-- `res` (Response): The `next.js` `getInitialProps` context `res` parameter
+- `isServer` (boolean): Indicates whether makeStore is executed on the server or the client side
+- `req` (Request): The `next.js` `getInitialProps` context `req` attribute
+- `res` (Response): The `next.js` `getInitialProps` context `res` attribute
 
-Additional config properties `req` and `res` are not set when client applies `initialState` from server.
+The `req` and `res` attributes are only set for the first server-side store ([Phase 1](#how-it-works)).
 
 Although it is possible to create server or client specific logic in both `makeStore` and `getInitialProps`, I highly
 recommend that they do not have different behavior. This may cause errors and checksum mismatches which in turn will
 ruin the whole purpose of server rendering.
 
-## Document
+## Tips and Tricks
+
+### Document
 
 I don't recommend using `withRedux` in `pages/_document.js`, Next.JS [does not provide](https://github.com/zeit/next.js/issues/1267)
 a reliable way to determine the sequence when components will be rendered. So per Next.JS recommendation it is better
-to have just data-agnostic things in `pages/_document`. 
+to have just data-agnostic things in `pages/_document`.
 
-## Error Pages
+### Error Pages
 
 Error pages can also be wrapped the same way as any other pages.
 
 Transition to an error page (`pages/_error.js` template) will cause `pages/_app.js` to be applied but it is always a
 full page transition (not HTML5 pushState), so client will have the store created from scratch using state from the server.
-So unless you persist the store on the client somehow the resulting previous client state will be ignored. 
+So unless you persist the store on the client somehow the resulting previous client state will be ignored.
 
-## Use with layout
+### Use with layout
 
 `MyApp` is not connected to Redux by design in order to keep the interface as minimal as possible. You can return
 whatever you want from `MyApp`'s `getInitialProps`, or if you need a shared layout just create it and `connect` it as
@@ -215,7 +319,7 @@ export default withRedux(makeStore, {debug: true})(class MyApp extends App {
 });
 ```
 
-## Async actions in `getInitialProps`
+### Async actions in `getInitialProps`
 
 ```js
 function someAsyncAction() {
@@ -226,23 +330,23 @@ function someAsyncAction() {
 }
 
 function getInitialProps({store, isServer, pathname, query}) {
-    
+
     // lets create an action using creator
     const action = someAsyncAction();
-    
+
     // now the action has to be dispatched
     store.dispatch(action);
-    
+
     // once the payload is available we can resume and render the app
     return action.payload.then((payload) => {
         // you can do something with payload now
-        return {custom: 'custom'}; 
+        return {custom: 'custom'};
     });
-    
+
 }
 ```
 
-## Custom serialization and deserialization
+### Custom serialization and deserialization
 
 If you are storing complex types such as Immutable.JS or EJSON objecs in your state, a custom serialize and deserialize
 handler might be handy to serialize the redux state on the server and derserialize it again on the client. To do so,
@@ -278,7 +382,7 @@ withRedux(
 );
 ```
 
-## Usage with Redux Saga
+### Usage with Redux Saga
 
 [Note, this method _may_ be unsafe - make sure you put a lot of thought into handling async sagas correctly. Race conditions happen very easily if you aren't careful.] To utilize Redux Saga, one simply has to make some changes to their `makeStore` function. Specifically, redux-saga needs to be initialized inside this function, rather than outside of it. (I did this at first, and got a nasty error telling me `Before running a Saga, you must mount the Saga middleware on the Store using applyMiddleware`). Here is how one accomplishes just that. This is just slightly modified from the setup example at the beginning of the docs.
 
@@ -294,16 +398,16 @@ const makeStore = (initialState, options) => {
 
     // 2: Add an extra parameter for applying middleware:
     const store = createStore(reducer, initialState, applyMiddleware(sagaMiddleware));
-   
+
     // 3: Run your sagas:
     sagaMiddleware.run(rootSaga);
-    
+
     // 4: now return the store:
     return store
 };
 ```
 
-## Usage with Redux Persist
+### Usage with Redux Persist
 
 Honestly, I think that putting a persistence gate is not necessary because the server can already send *some* HTML with
 *some* state, so it's better to show it right away and then wait for `REHYDRATE` action to happen to show additional
@@ -426,7 +530,7 @@ Which brings us to the conclusion:
 
 If you need a static website you don't need this lib at all because you can always dispatch at client side on `componentDidMount` just like you normally would with bare React Redux, and let the server only serve initial/static markup.
 
-## Upgrade
+## Upgrade from 1.x
 
 If your project was using NextJS 5 and Next Redux Wrapper 1.x these instructions will help you to upgrade to latest
 version.
@@ -436,18 +540,18 @@ version.
     $ npm install next@6 --save-dev
     $ npm install next-redux-wrapper@latest --save
    ```
-   
+
 2. Replace all usages of `import withRedux from "next-redux-wrapper";` and `withRedux(...)(WrappedComponent)` in all
     your pages with plain React Redux `connect` HOC:
-    
+
     ```js
     import {connect} from "react-redux";
-    
+
     export default connect(...)(WrappedComponent);
     ```
-    
+
     You also may have to reformat your wrapper object-based config to simple React Redux config.
-    
+
 3. Create the `pages/_app.js` file with the following minimal code:
 
     ```js
@@ -457,9 +561,9 @@ version.
     import App, {Container} from "next/app";
     import withRedux from "next-redux-wrapper";
     import {makeStore} from "../components/store";
-    
+
     export default withRedux(makeStore, {debug: true})(class MyApp extends App {
-    
+
         static async getInitialProps({Component, ctx}) {
             return {
                 pageProps: {
@@ -468,7 +572,7 @@ version.
                 }
             };
         }
-    
+
         render() {
             const {Component, pageProps, store} = this.props;
             return (
@@ -479,18 +583,17 @@ version.
                 </Container>
             );
         }
-    
+
     });
     ```
 
 4. Follow [NextJS 6 upgrade instructions](https://github.com/zeit/next.js/issues/4239) for all your components
     (`props.router` instead of `props.url` and so on)
-    
-That's it. Your project should now work the same as before. 
+
+That's it. Your project should now work the same as before.
 
 ## Resources
 
 * [next-redux-saga](https://github.com/bmealhouse/next-redux-saga)
 * [How to use with Redux and Redux Saga](https://www.robinwieruch.de/nextjs-redux-saga/)
 * Redux Saga Example: https://gist.github.com/pesakitan22/94b4984140ba0f2c9e52c5289a7d833e.
-* [Typescript type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/next-redux-wrapper) > `npm install @types/next-redux-wrapper`


### PR DESCRIPTION
* Add motivation section (#170)
* Add TypeScript examples (#176, #177)
* Make installation code blocks expandable
* Migrate connected Page components to functional components
* Group tips and examples in a Tips and Tricks section
* Some grammar & style improvements
* Remove outdated typings reference in Resources section
* Add npm package badge
* Remove deprecated Container notice

I didn't find time to walk through the Tips and Tricks section yet – I think it could profit from TS examples as well.