### PR TITLE
Add Redux Hooks usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This library is compatible with NextJS 9, but it is not compatible with [NextJS 
 - [Custom serialization and deserialization, usage with Immutable.JS](#custom-serialization-and-deserialization)
 - [Usage with Redux Saga](#usage-with-redux-saga)
 - [Usage with Redux Persist](#usage-with-redux-persist)
+- [Usage with Redux Hooks](#usage-with-redux-hooks)
 - [Upgrade from 1.x](#upgrade)
 - [Resources](#resources)
 
@@ -415,6 +416,49 @@ export default connect(
     </div>
 ));
 ```
+
+## Usage with Redux Hooks
+
+In order to use Redux Hooks you need to use `useSelector` and `useDispatch` hooks instead of `connect` with `mapStateToProps` and `mapDispatchToProps`. To do so you will need to use `withRedux` as stated in [installation](#installation).
+
+From now on, all your components will have access to the redux store (since we used `withRedux` in the `_app` component) and you'll have to remove the `connect` HOC (normal redux) in favour of `useSelector` and `useDispatch` as stated in the previous parragraph. E.g:
+
+```jsx
+const MyComponent = (props) => {
+  const {mappedValueFromStore} = props
+  const storeValue = useSelector(state => state.storeValue) // Client side only
+  const dispatch = useDispatch() // Client side only
+
+  const triggerChange = () => {
+    dispatch({
+      type: 'CHANGE_STORE_VALUE',
+      storeValue: 'new store value'
+    })
+  }
+
+  return (
+    <div>
+      <p>From store directly: {storeValue}</p>
+      <p>From mapped props: {mappedValueFromStore}</p>
+      <button onClick={triggerChange}>Trigger change</button>
+    </div>
+  )
+}
+
+MyComponent.getInitialProps = async (ctx) => {
+  // Server side usage
+  const mappedValueFromStore = ctx.store.state.mappedValueFromStore // we can retrieve data from redux store
+  ctx.store.dispatch({
+    type: 'ACCESS_FROM_GET_INITIAL_PROPS'
+  }) // We can dispatch actions too
+
+  return {
+    mappedValueFromStore,
+  }
+}
+```
+
+We can use it both server and client side, using `ctx.store.state` and `ctx.store.dispatch` server side and with the hooks on the client side.
 
 ## Automatic Partial Static Export
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,6 @@ const MyComponent = (props) => {
 }
 
 MyComponent.getInitialProps = async (ctx) => {
-  // Server side usage
   const mappedValueFromStore = ctx.store.state.mappedValueFromStore // we can retrieve data from redux store in getInitialProps
   ctx.store.dispatch({
     type: 'ACCESS_FROM_GET_INITIAL_PROPS'

--- a/README.md
+++ b/README.md
@@ -529,10 +529,12 @@ From now on, all your components will have access to the redux store (since we u
 ```jsx
 const MyComponent = (props) => {
   const {mappedValueFromStore} = props
-  const storeValue = useSelector(state => state.storeValue) // Client side only
-  const dispatch = useDispatch() // Client side only
+  // Regular redux hooks usage
+  const storeValue = useSelector(state => state.storeValue)
+  const dispatch = useDispatch()
 
   const triggerChange = () => {
+    // Dispatch a redux action with redux hooks
     dispatch({
       type: 'CHANGE_STORE_VALUE',
       storeValue: 'new store value'
@@ -550,7 +552,7 @@ const MyComponent = (props) => {
 
 MyComponent.getInitialProps = async (ctx) => {
   // Server side usage
-  const mappedValueFromStore = ctx.store.state.mappedValueFromStore // we can retrieve data from redux store
+  const mappedValueFromStore = ctx.store.state.mappedValueFromStore // we can retrieve data from redux store in getInitialProps
   ctx.store.dispatch({
     type: 'ACCESS_FROM_GET_INITIAL_PROPS'
   }) // We can dispatch actions too


### PR DESCRIPTION
This PR adds reudx hooks usage documentation, providing an example for its usage.

Also "fixes" #163 .