### PR TITLE
fix(wrapper): add typing for Store super-types

### DIFF
--- a/packages/demo-page/src/components/store.tsx
+++ b/packages/demo-page/src/components/store.tsx
@@ -1,9 +1,9 @@
-import {createStore, applyMiddleware} from 'redux';
+import {createStore, applyMiddleware, Store} from 'redux';
 import logger from 'redux-logger';
 import {MakeStore, createWrapper, Context} from 'next-redux-wrapper';
 import reducer, {State} from './reducer';
 
-export const makeStore: MakeStore<State> = (context: Context) => {
+export const makeStore: MakeStore<Store<State>> = (context: Context) => {
     const store = createStore(reducer, applyMiddleware(logger));
 
     if (module.hot) {
@@ -16,4 +16,4 @@ export const makeStore: MakeStore<State> = (context: Context) => {
     return store;
 };
 
-export const wrapper = createWrapper<State>(makeStore, {debug: true});
+export const wrapper = createWrapper(makeStore, {debug: true});

--- a/packages/demo-saga-page/src/components/store.tsx
+++ b/packages/demo-saga-page/src/components/store.tsx
@@ -2,22 +2,22 @@ import {createStore, applyMiddleware, Store} from 'redux';
 import logger from 'redux-logger';
 import createSagaMiddleware, {Task} from 'redux-saga';
 import {MakeStore, Context, createWrapper} from 'next-redux-wrapper';
-import reducer, {State} from './reducer';
+import reducer from './reducer';
 import rootSaga from './saga';
 
 export interface SagaStore extends Store {
     sagaTask: Task;
 }
 
-const makeStore: MakeStore<State> = (context: Context) => {
+const makeStore: MakeStore<SagaStore> = (context: Context) => {
     // 1: Create the middleware
     const sagaMiddleware = createSagaMiddleware();
 
     // 2: Add an extra parameter for applying middleware:
-    const store = createStore(reducer, applyMiddleware(sagaMiddleware, logger));
+    const store = createStore(reducer, applyMiddleware(sagaMiddleware, logger)) as SagaStore;
 
     // 3: Run your sagas on server
-    (store as SagaStore).sagaTask = sagaMiddleware.run(rootSaga);
+    store.sagaTask = sagaMiddleware.run(rootSaga);
 
     // 4: now return the store:
     return store;

--- a/packages/demo-saga/src/components/store.tsx
+++ b/packages/demo-saga/src/components/store.tsx
@@ -2,22 +2,22 @@ import {createStore, applyMiddleware, Store} from 'redux';
 import logger from 'redux-logger';
 import createSagaMiddleware, {Task} from 'redux-saga';
 import {MakeStore, Context} from 'next-redux-wrapper';
-import reducer, {State} from './reducer';
+import reducer from './reducer';
 import rootSaga from './saga';
 
 export interface SagaStore extends Store {
     sagaTask: Task;
 }
 
-export const makeStore: MakeStore<State> = (context: Context) => {
+export const makeStore: MakeStore<SagaStore> = (context: Context) => {
     // 1: Create the middleware
     const sagaMiddleware = createSagaMiddleware();
 
     // 2: Add an extra parameter for applying middleware:
-    const store = createStore(reducer, applyMiddleware(sagaMiddleware, logger));
+    const store = createStore(reducer, applyMiddleware(sagaMiddleware, logger)) as SagaStore;
 
     // 3: Run your sagas on server
-    (store as SagaStore).sagaTask = sagaMiddleware.run(rootSaga);
+    store.sagaTask = sagaMiddleware.run(rootSaga);
 
     // 4: now return the store:
     return store;

--- a/packages/demo/src/components/store.tsx
+++ b/packages/demo/src/components/store.tsx
@@ -1,9 +1,9 @@
-import {createStore, applyMiddleware} from 'redux';
+import {createStore, applyMiddleware, Store} from 'redux';
 import logger from 'redux-logger';
 import {MakeStore, createWrapper, Context} from 'next-redux-wrapper';
 import reducer, {State} from './reducer';
 
-export const makeStore: MakeStore<State> = (context: Context) => {
+export const makeStore: MakeStore<Store<State>> = (context: Context) => {
     const store = createStore(reducer, applyMiddleware(logger));
 
     if (module.hot) {
@@ -16,4 +16,4 @@ export const makeStore: MakeStore<State> = (context: Context) => {
     return store;
 };
 
-export const wrapper = createWrapper<State>(makeStore, {debug: true});
+export const wrapper = createWrapper(makeStore, {debug: true});


### PR DESCRIPTION
Since the current implementation uses a hard-coded [`Store`](https://github.com/reduxjs/redux/blob/master/src/types/store.ts#L127) everywhere, it's impossible the have typing of stores which `extends Store`, e.g [Redux Toolkit's `EnhancedStore`](https://github.com/reduxjs/redux-toolkit/blob/15de83474160b867475872aeaaac01a9c750f53a/src/configureStore.ts#L102-L106):

```ts
export interface EnhancedStore<
  S = any,
  A extends Action = AnyAction,
  M extends Middlewares<S> = Middlewares<S>
> extends Store<S, A>
```

---

The changes I've introduced allow, for example, to use `store.dispatch()` with [`ThunkAction`](https://github.com/reduxjs/redux-thunk/blob/master/src/index.d.ts#L50)s.

Now, instead of this:

```ts
// store.ts
const makeStore = () => configureStore({ reducer })
export type AppDispatch = ReturnType<typeof makeStore>["dispatch"]

// index.tsx
export const getStaticProps = wrapper.getStaticProps(async ({ store }) => {
  const dispatch = store.dispatch as AppDispatch
  await dispatch(fetchSomething())
})
```

We can do this:

```ts
// index.tsx
export const getStaticProps = wrapper.getStaticProps(async ({ store }) => {
  await store.dispatch(fetchSomething())
})
```

---

Fixes #207, fixes #240