### PR TITLE
Fix wrapper.getInitialAppProps() incompatible with Next's AppInitialProps

### DIFF
--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -1,4 +1,4 @@
-import App, {AppContext, AppInitialProps} from 'next/app';
+import App, {AppContext} from 'next/app';
 import React from 'react';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
@@ -92,7 +92,13 @@ export const createWrapper = <S extends Store>(makeStore: MakeStore<S>, config: 
 
     const getInitialAppProps = <P extends {} = any>(callback: AppCallback<S, P>): GetInitialAppProps<P> => async (
         context: AppContext,
-    ) => (await makeProps({callback, context})) as WrapperProps & AppInitialProps; // this is just to convince TS
+    ) => {
+        const {initialProps, ...props} = await makeProps({callback, context});
+        return {
+            ...initialProps,
+            ...props,
+        };
+    };
 
     const getStaticProps = <P extends {} = any>(
         callback: GetStaticPropsCallback<S, P>,
@@ -233,9 +239,8 @@ export interface Config<S extends Store> {
 }
 
 export interface WrapperProps {
-    initialProps: any; // stuff returned from getInitialProps
+    initialProps: any; // stuff returned from getInitialProps or getServerSideProps
     initialState: any; // stuff in the Store state after getInitialProps
-    pageProps?: any; // stuff from page's getServerSideProps or getInitialProps when used with App
 }
 
 type GetInitialPageProps<P> = NextComponentType<NextPageContext, any, P>['getInitialProps'];

--- a/packages/wrapper/tests/server.spec.tsx
+++ b/packages/wrapper/tests/server.spec.tsx
@@ -41,7 +41,7 @@ describe('function API', () => {
             });
 
             expect(await wrapper.withRedux(App)?.getInitialProps({ctx})).toEqual({
-                initialProps: {pageProps},
+                pageProps,
                 initialState,
             });
         });
@@ -61,7 +61,7 @@ describe('function API', () => {
             const initialAppProps = await wrapper.withRedux(App)?.getInitialProps(context);
 
             expect(initialAppProps).toEqual({
-                initialProps: {pageProps: {fromApp: true}},
+                pageProps: {fromApp: true},
                 initialState: {reduxStatus: 'app'},
             });
 
@@ -84,7 +84,11 @@ describe('function API', () => {
 
             const resultingProps = {
                 ...initialAppProps,
-                pageProps: (serverSideProps as any).props, // NextJS will wrap it like this
+                pageProps: {
+                    // NextJS will wrap it like this
+                    ...initialAppProps.pageProps,
+                    ...(serverSideProps as any).props,
+                },
             };
 
             const WrappedPage: any = wrapper.withRedux(DummyComponent);


### PR DESCRIPTION
PR fixes issue described in https://github.com/kirill-konshin/next-redux-wrapper/issues/325