### PR TITLE
Reference next-redux-cookie-wrapper in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,9 @@ const reducer = (state = {tick: 'init'}, action) => {
 ```
 </details>
 
+If you prefer an isomorphic approach for some (preferably small) portions of your state, you can share them between client and server on server-rendered pages using [next-redux-cookie-wrapper](https://github.com/bjoluc/next-redux-cookie-wrapper), an extension to next-redux-wrapper.
+In this case, for selected substates, the server is aware of the client's state (unless in `getStaticProps`) and there is no need to separate server and client state.
+
 Also you can use a library like https://github.com/benjamine/jsondiffpatch to analyze diff and apply it properly.
 
 ### Document
@@ -1024,6 +1027,8 @@ If you don't want to opt-out of automatic pre-rendering in your Next.js app, you
 
 ### Usage with Redux Persist
 
+> If you only need to persist small portions of your state, [next-redux-cookie-wrapper](https://github.com/bjoluc/next-redux-cookie-wrapper) might be an easy alternative to Redux Persist that supports SSR.
+
 Boilerplate: https://github.com/fazlulkarimweb/with-next-redux-wrapper-redux-persist
 
 Honestly, I think that putting a persistence gate is not necessary because the server can already send *some* HTML with
@@ -1243,3 +1248,4 @@ That's it. Your project should now work the same as before.
 * [next-redux-saga](https://github.com/bmealhouse/next-redux-saga)
 * [How to use with Redux and Redux Saga](https://www.robinwieruch.de/nextjs-redux-saga/)
 * Redux Saga Example: https://gist.github.com/pesakitan22/94b4984140ba0f2c9e52c5289a7d833e.
+* [next-redux-cookie-wrapper](https://github.com/bjoluc/next-redux-cookie-wrapper)


### PR DESCRIPTION
Hi @kirill-konshin, it's me again tinkering with the readme :smile:
I've been maintaining a little library called [next-redux-cookie-wrapper](https://github.com/bjoluc/next-redux-cookie-wrapper) for a while now that started as a drop-in replacement to next-redux-wrapper, configuring next-redux-wrapper to use Redux Persist and redux-persist-cookie-storage for improved SSR. Recently, I rewrote the whole thing to support next-redux-wrapper v6 and v7 and get rid of Redux Persist. Instead of a drop-in replacement, it is now an extension to next-redux-wrapper that ships as a Redux middleware.
I figured this might be of interest for a broader audience now, so this PR adds a few references to the readme where applicable. I hope they are neither to bold, nor to many. Thanks in advance for considering this!