### PR TITLE
Simplify slice creation in redux-toolkit demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,14 +641,12 @@ Consider using [Redux persist](#usage-with-redux-persist) if you want to persist
 
 Since version `7.0` first-class support of `@reduxjs/toolkit` has been added.
 
-Full example: https://github.com/kirill-konshin/next-redux-wrapper/blob/master/packages/demo/package.json.
+Full example: https://github.com/kirill-konshin/next-redux-wrapper/blob/master/packages/demo-redux-toolkit.
 
 ```ts
-import {configureStore, createAction, createSlice, ThunkAction} from '@reduxjs/toolkit';
+import {configureStore, createSlice, ThunkAction} from '@reduxjs/toolkit';
 import {Action} from 'redux';
 import {createWrapper, HYDRATE} from 'next-redux-wrapper';
-
-const hydrate = createAction<AppState>(HYDRATE);
 
 export const slice = createSlice({
     name: 'some',
@@ -663,14 +661,14 @@ export const slice = createSlice({
         },
     },
 
-    extraReducers(builder) {
-        builder.addCase(hydrate, (state, action) => {
+    extraReducers: {
+        [HYDRATE]: (state, action) => {
             console.log('HYDRATE', state, action.payload);
             return {
                 ...state,
-                ...(action.payload as any)[slice.name],
+                ...action.payload.some,
             };
-        });
+        },
     },
 });
 

--- a/packages/demo-redux-toolkit/store.tsx
+++ b/packages/demo-redux-toolkit/store.tsx
@@ -1,8 +1,6 @@
-import {configureStore, createAction, createSlice, ThunkAction} from '@reduxjs/toolkit';
+import {configureStore, createSlice, ThunkAction} from '@reduxjs/toolkit';
 import {Action} from 'redux';
 import {createWrapper, HYDRATE} from 'next-redux-wrapper';
-
-const hydrate = createAction<AppState>(HYDRATE);
 
 export const subjectSlice = createSlice({
     name: 'subject',
@@ -15,14 +13,14 @@ export const subjectSlice = createSlice({
         },
     },
 
-    extraReducers(builder) {
-        builder.addCase(hydrate, (state, action) => {
+    extraReducers: {
+        [HYDRATE]: (state, action) => {
             console.log('HYDRATE', state, action.payload);
             return {
                 ...state,
-                ...action.payload[subjectSlice.name],
+                ...action.payload.subject,
             };
-        });
+        },
     },
 });
 


### PR DESCRIPTION
Per the `createSlice` documentation, `extraReducers` can also be "a mapping from action types to action-type-specific case reducer functions". That removes the need for
```ts
const hydrate = createAction<AppState>(HYDRATE);
```
like in the `builder.addCase()` approach.
This PR also removes the (circular) slice.name reference in the HYDRATE reducer as it breaks type inference for the slice. A tiny bit of redundancy is better than untyped slices, I guess.