### PR TITLE
Remove ctx.store and use getInitialPageProps() instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,8 +441,7 @@ class MyApp extends App<AppInitialProps> {
         return {
             pageProps: {
                 // Call page-level getInitialProps
-                // DON'T FORGET TO PROVIDE STORE TO PAGE
-                ...(Component.getInitialProps ? await Component.getInitialProps({...ctx, store}) : {}),
+                ...(Component.getInitialProps ? await Component.getInitialProps(ctx) : {}),
                 // Some custom thing for all pages
                 pathname: ctx.pathname,
             },
@@ -480,8 +479,7 @@ class MyApp extends App {
         return {
             pageProps: {
                 // Call page-level getInitialProps
-                // DON'T FORGET TO PROVIDE STORE TO PAGE
-                ...(Component.getInitialProps ? await Component.getInitialProps({...ctx, store}) : {}),
+                ...(Component.getInitialProps ? await Component.getInitialProps(ctx) : {}),
                 // Some custom thing for all pages
                 pathname: ctx.pathname,
             },

--- a/packages/demo-saga/src/pages/_app.tsx
+++ b/packages/demo-saga/src/pages/_app.tsx
@@ -1,25 +1,11 @@
 import React from 'react';
 import App, {AppContext, AppInitialProps} from 'next/app';
-import {END} from 'redux-saga';
-import {SagaStore, wrapper} from '../components/store';
+import {wrapper} from '../components/store';
 
 class WrappedApp extends App<AppInitialProps> {
     public static getInitialProps = wrapper.getInitialAppProps(store => async ({Component, ctx}: AppContext) => {
-        // 1. Wait for all page actions to dispatch
-        const pageProps = {
-            ...(Component.getInitialProps ? await Component.getInitialProps({...ctx, store}) : {}),
-        };
-
-        // 2. Stop the saga if on server
-        if (ctx.req) {
-            console.log('Saga is executing on server, we will wait');
-            store.dispatch(END);
-            await (store as SagaStore).sagaTask.toPromise();
-        }
-
-        // 3. Return props
         return {
-            pageProps,
+            pageProps: Component.getInitialProps ? await Component.getInitialProps(ctx) : {},
         };
     });
 

--- a/packages/demo-saga/src/pages/index.tsx
+++ b/packages/demo-saga/src/pages/index.tsx
@@ -3,6 +3,8 @@ import {useSelector} from 'react-redux';
 import {NextPage} from 'next';
 import {State} from '../components/reducer';
 import {SAGA_ACTION} from '../components/saga';
+import {SagaStore, wrapper} from '../components/store';
+import {END} from '@redux-saga/core';
 
 export interface ConnectedPageProps {
     custom: string;
@@ -18,9 +20,17 @@ const Page: NextPage<ConnectedPageProps> = ({custom}: ConnectedPageProps) => {
     );
 };
 
-Page.getInitialProps = async ({store}) => {
+Page.getInitialProps = wrapper.getInitialPageProps(store => async ctx => {
     store.dispatch({type: SAGA_ACTION});
+
+    // Stop the saga if on server
+    if (ctx.req) {
+        console.log('Saga is executing on server, we will wait');
+        store.dispatch(END);
+        await (store as SagaStore).sagaTask.toPromise();
+    }
+
     return {custom: 'custom'};
-};
+});
 
 export default Page;

--- a/packages/demo/src/pages/_app.tsx
+++ b/packages/demo/src/pages/_app.tsx
@@ -12,7 +12,7 @@ class WrappedApp extends App<AppInitialProps> {
                 pageProps: {
                     // Call page-level getInitialProps manually, instead of App.getInitialProps
                     // Documentation: https://nextjs.org/docs/advanced-features/custom-app
-                    ...(Component.getInitialProps ? await Component.getInitialProps({...ctx, store}) : {}),
+                    ...(Component.getInitialProps ? await Component.getInitialProps(ctx) : {}),
                     // Some custom thing for all pages
                     appProp: ctx.pathname,
                 },

--- a/packages/demo/src/pages/index.tsx
+++ b/packages/demo/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import {connect} from 'react-redux';
 import {NextPageContext} from 'next';
 import {State} from '../components/reducer';
+import {wrapper} from '../components/store';
 
 export interface PageProps extends State {
     pageProp: string;
@@ -11,23 +12,25 @@ export interface PageProps extends State {
 
 class Index extends React.Component<PageProps> {
     // note that since _app is wrapped no need to wrap page
-    public static async getInitialProps({store, pathname, query, req}: NextPageContext) {
-        console.log('2. Page.getInitialProps uses the store to dispatch things', {pathname, query});
+    public static getInitialProps = wrapper.getInitialPageProps(
+        store => async ({pathname, query, req}: NextPageContext) => {
+            console.log('2. Page.getInitialProps uses the store to dispatch things', {pathname, query});
 
-        if (req) {
-            // All async actions must be await'ed
-            await store.dispatch({type: 'PAGE', payload: 'server'});
+            if (req) {
+                // All async actions must be await'ed
+                await store.dispatch({type: 'PAGE', payload: 'server'});
+
+                // Some custom thing for this particular page
+                return {pageProp: 'server'};
+            }
+
+            // await is not needed if action is synchronous
+            store.dispatch({type: 'PAGE', payload: 'client'});
 
             // Some custom thing for this particular page
-            return {pageProp: 'server'};
-        }
-
-        // await is not needed if action is synchronous
-        store.dispatch({type: 'PAGE', payload: 'client'});
-
-        // Some custom thing for this particular page
-        return {pageProp: 'client'};
-    }
+            return {pageProp: 'client'};
+        },
+    );
 
     public render() {
         // console.log('5. Page.render');

--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -278,13 +278,3 @@ export type Callback<S extends Store, P> =
     | GetServerSidePropsCallback<S, P>
     | PageCallback<S, P>
     | AppCallback<S, P>;
-
-declare module 'next/dist/next-server/lib/utils' {
-    export interface NextPageContext<S extends Store = any> {
-        //<S = any, A extends Action = AnyAction>
-        /**
-         * Provided by next-redux-wrapper: The redux store
-         */
-        store: S;
-    }
-}


### PR DESCRIPTION
Blocker: #382

- Remove legacy ctx.store type.
- Use getInitialPageProps() for everywhere in demo, as 6.x to 7.x migration doc says.

For demo-saga, modified to wait for saga in page not _app: not doing so will cause empty state because getInitialPageProps() returns empty initialState.
Below code dispatches HYDRATE with empty state.
https://github.com/kirill-konshin/next-redux-wrapper/blob/fc056a99875dd327a1bec36dfc15dd4a4b90b33b/packages/wrapper/src/index.tsx#L177-L181