### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,16 +648,14 @@ import {configureStore, createSlice, ThunkAction} from '@reduxjs/toolkit';
 import {Action} from 'redux';
 import {createWrapper, HYDRATE} from 'next-redux-wrapper';
 
-export const slice = createSlice({
-    name: 'some',
+export const subjectSlice = createSlice({
+    name: 'subject',
 
-    initialState: {
-        whatever: null,
-    },
+    initialState: {} as any,
 
     reducers: {
-        setWhatever(state, action) {
-            state.whatever = action.payload;
+        setEnt(state, action) {
+            return action.payload;
         },
     },
 
@@ -666,7 +664,7 @@ export const slice = createSlice({
             console.log('HYDRATE', state, action.payload);
             return {
                 ...state,
-                ...action.payload.some,
+                ...action.payload.subject,
             };
         },
     },
@@ -675,21 +673,33 @@ export const slice = createSlice({
 const makeStore = () =>
     configureStore({
         reducer: {
-            [slice.name]: slice.reducer,
-        }
+            [subjectSlice.name]: subjectSlice.reducer,
+        },
+        devTools: true,
     });
 
 export type AppStore = ReturnType<typeof makeStore>;
 export type AppState = ReturnType<AppStore['getState']>;
 export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, AppState, unknown, Action>;
 
-export const someAction = (whatever: any): AppThunk => async dispatch => {
+export const fetchSubject = (id: any): AppThunk => async dispatch => {
+    const timeoutPromise = (timeout: number) => new Promise(resolve => setTimeout(resolve, timeout));
+
+    await timeoutPromise(200);
+
     dispatch(
-        subjectSlice.actions.setWhatever({ whatever }),
+        subjectSlice.actions.setEnt({
+            [id]: {
+                id,
+                name: `Subject ${id}`,
+            },
+        }),
     );
 };
 
 export const wrapper = createWrapper<AppStore>(makeStore);
+
+export const selectSubject = (id: any) => (state: AppState) => state?.[subjectSlice.name]?.[id];
 ```
 
 It is recommended to export typed `State` and `ThunkAction`:


### PR DESCRIPTION
After finding the repo and giving the redux toolkit example a try I noticed that there was inconsistencies with the code block provided in the main repo README such as referencing a variable that does not exist (`subjectSlice`). 

I have copied in the store snippet from https://github.com/kirill-konshin/next-redux-wrapper/tree/master/packages/demo-redux-toolkit 