### PR TITLE
Add support for complex sagas asynchronously initializing the store state at server-side

### DIFF
--- a/packages/demo-saga-page/src/components/store.tsx
+++ b/packages/demo-saga-page/src/components/store.tsx
@@ -1,26 +1,33 @@
 import {createStore, applyMiddleware, Store} from 'redux';
 import logger from 'redux-logger';
 import createSagaMiddleware, {Task} from 'redux-saga';
-import {Context, createWrapper} from 'next-redux-wrapper';
+import {Context, createInitSagaMonitor, createWrapper, InitSagaMonitor} from 'next-redux-wrapper';
 import reducer, {State} from './reducer';
 import rootSaga from './saga';
 
 export interface SagaStore extends Store<State> {
+    initMonitor: InitSagaMonitor;
     sagaTask: Task;
 }
 
-const makeStore = (context: Context) => {
+const INITIALIZATION_TIMEOUT = 30_000; // 30 seconds
+
+const makeStore = (context: Context): SagaStore => {
     // 1: Create the middleware
-    const sagaMiddleware = createSagaMiddleware();
+    const initMonitor = createInitSagaMonitor(INITIALIZATION_TIMEOUT);
+    const sagaMiddleware = createSagaMiddleware({sagaMonitor: initMonitor.monitor});
 
     // 2: Add an extra parameter for applying middleware:
     const store = createStore(reducer, applyMiddleware(sagaMiddleware, logger));
 
     // 3: Run your sagas on server
-    (store as SagaStore).sagaTask = sagaMiddleware.run(rootSaga);
+    const sagaTask = sagaMiddleware.run(rootSaga);
 
-    // 4: now return the store:
-    return store;
+    // 4: Now return the store with access to init monitor and root saga task
+    return Object.assign(store, {
+        initMonitor,
+        sagaTask,
+    });
 };
 
 export const wrapper = createWrapper<SagaStore>(makeStore as any);

--- a/packages/demo-saga-page/src/pages/index.tsx
+++ b/packages/demo-saga-page/src/pages/index.tsx
@@ -21,9 +21,12 @@ const Page: NextPage<ConnectedPageProps> = ({custom}: ConnectedPageProps) => {
 };
 
 export const getServerSideProps = wrapper.getServerSideProps(store => async () => {
-    store.dispatch({type: SAGA_ACTION});
-    store.dispatch(END);
-    await (store as SagaStore).sagaTask.toPromise();
+    const sagaStore = store as SagaStore;
+    sagaStore.dispatch({type: SAGA_ACTION});
+    sagaStore.initMonitor.start(); // Start the init monitor after sagas started to do their work
+    await sagaStore.initMonitor.initCompletion;
+    sagaStore.dispatch(END);
+    await sagaStore.sagaTask.toPromise();
 
     return {props: {custom: 'custom'}};
 });

--- a/packages/demo-saga/src/components/store.tsx
+++ b/packages/demo-saga/src/components/store.tsx
@@ -1,26 +1,33 @@
 import {createStore, applyMiddleware, Store} from 'redux';
 import logger from 'redux-logger';
 import createSagaMiddleware, {Task} from 'redux-saga';
-import {Context, createWrapper} from 'next-redux-wrapper';
+import {Context, createInitSagaMonitor, createWrapper, InitSagaMonitor} from 'next-redux-wrapper';
 import reducer from './reducer';
 import rootSaga from './saga';
 
 export interface SagaStore extends Store {
+    initMonitor: InitSagaMonitor;
     sagaTask: Task;
 }
 
+const INITIALIZATION_TIMEOUT = 30_000; // 30 seconds
+
 export const makeStore = (context: Context) => {
     // 1: Create the middleware
-    const sagaMiddleware = createSagaMiddleware();
+    const initMonitor = createInitSagaMonitor(INITIALIZATION_TIMEOUT);
+    const sagaMiddleware = createSagaMiddleware({sagaMonitor: initMonitor.monitor});
 
     // 2: Add an extra parameter for applying middleware:
     const store = createStore(reducer, applyMiddleware(sagaMiddleware, logger));
 
     // 3: Run your sagas on server
-    (store as SagaStore).sagaTask = sagaMiddleware.run(rootSaga);
+    const sagaTask = sagaMiddleware.run(rootSaga);
 
-    // 4: now return the store:
-    return store;
+    // 4: Now return the store with access to init monitor and root saga task
+    return Object.assign(store, {
+        initMonitor,
+        sagaTask,
+    });
 };
 
 export const wrapper = createWrapper<SagaStore>(makeStore as any);

--- a/packages/demo-saga/src/pages/_app.tsx
+++ b/packages/demo-saga/src/pages/_app.tsx
@@ -11,10 +11,13 @@ class MyApp extends React.Component<AppProps> {
             ...(await App.getInitialProps(context)).pageProps,
         };
 
-        // 2. Stop the saga if on server
+        // 2. Stop the saga if on server once the initialization is done
         if (context.ctx.req) {
-            store.dispatch(END);
-            await (store as SagaStore).sagaTask.toPromise();
+            const sagaStore = store as SagaStore;
+            sagaStore.initMonitor.start(); // Start the init monitor after sagas started to do their work
+            await sagaStore.initMonitor.initCompletion;
+            sagaStore.dispatch(END);
+            await sagaStore.sagaTask.toPromise();
         }
 
         // 3. Return props

--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -11,6 +11,8 @@ import {
     NextPageContext,
 } from 'next';
 
+export * from './initSagaMonitorFactory';
+
 /**
  * Quick note on Next.js return types:
  *

--- a/packages/wrapper/src/initSagaMonitorFactory.ts
+++ b/packages/wrapper/src/initSagaMonitorFactory.ts
@@ -1,0 +1,180 @@
+import {SagaMonitor} from '@redux-saga/core';
+import {effect as isEffect, task as isTask} from '@redux-saga/is';
+import {Effect} from '@redux-saga/types';
+import {spawn} from 'redux-saga/effects';
+
+export const DEFAULT_TIMEOUT = 120_000; // 2 minutes. No timeouts at all are generally a very bad idea.
+
+export interface InitSagaMonitor {
+    readonly monitor: SagaMonitor;
+    readonly initCompletion: Promise<void>;
+    readonly start: () => void;
+}
+
+export default function createInitSagaMonitor(timeout = DEFAULT_TIMEOUT): InitSagaMonitor {
+    const rootEffects: MonitoredEffect[] = [];
+    const effectIdToEffectIndex = new Map<number, MonitoredEffect>();
+
+    let initCompletionResolver!: () => void;
+    let initCompletionRejector!: (error: Error) => void;
+    let isStarted = false;
+    let isResolved = false;
+    let monitor!: SagaMonitor;
+
+    const initCompletion = new Promise<void>((resolve, reject) => {
+        initCompletionResolver = resolve;
+        initCompletionRejector = reject;
+        monitor = {
+            rootSagaStarted({effectId, saga, args}): void {
+                registerEffect(effectId, null, spawn(saga, ...args));
+            },
+            effectTriggered({effectId, parentEffectId, effect}): void {
+                if (isEffect(effect)) {
+                    registerEffect(effectId, parentEffectId, effect);
+                    if (effect.type === 'TAKE') {
+                        checkInitCompletion();
+                    }
+                }
+            },
+            effectResolved(effectId, result): void {
+                const effect = effectIdToEffectIndex.get(effectId);
+                if (effect) {
+                    if (isTask(result)) {
+                        result.toPromise().then(() => {
+                            effect.isPending = false;
+                            checkInitCompletion();
+                        }, (error) => {
+                            isResolved = true;
+                            reject(error);
+                        });
+                    } else {
+                        effect.isPending = false;
+                        checkInitCompletion();
+                    }
+                }
+            },
+            effectRejected(effectId): void {
+                resolveFailedOrCancelledEffect(effectId);
+            },
+            effectCancelled(effectId): void {
+                resolveFailedOrCancelledEffect(effectId);
+            },
+        };
+    });
+
+    return {
+        initCompletion,
+        monitor,
+        start(): void {
+            if (isStarted) {
+                throw new Error('This init monitor has already been started. Please create a new one for every redux store.');
+            }
+
+            isStarted = true;
+
+            if (timeout > 0) {
+                setTimeout(() => {
+                    if (isResolved) {
+                        return;
+                    }
+
+                    isResolved = true;
+                    const pendingEffects = trimResolvedEffects(rootEffects);
+                    initCompletionRejector(Object.assign(new Error(
+                        `The following redux saga effects did not finish or block on a take effect within the configured timeout of ${timeout} ` +
+                        `milliseconds:\n${formatEffectForest(pendingEffects)}`,
+                    ), {name: 'TimeoutError', timeout}));
+                }, timeout);
+            }
+
+            checkInitCompletion();
+        },
+    };
+
+    function registerEffect(effectId: number, parentId: number | null, descriptor: Effect): void {
+        const effect: MonitoredEffect = {
+            id: effectId,
+            parent: (parentId !== null && effectIdToEffectIndex.get(parentId)) || null,
+            descriptor,
+            children: [],
+            isPending: true,
+        };
+        if (effect.parent === null) {
+            rootEffects.push(effect);
+        } else {
+            effect.parent.children.push(effect);
+        }
+        effectIdToEffectIndex.set(effectId, effect);
+    }
+
+    function resolveFailedOrCancelledEffect(effectId: number): void {
+        const effect = effectIdToEffectIndex.get(effectId);
+        if (effect) {
+            effect.isPending = false;
+        }
+    }
+
+    function checkInitCompletion(): void {
+        if (isStarted && !isResolved && isInitCompleted(rootEffects)) {
+            isResolved = true;
+            initCompletionResolver();
+        }
+    }
+}
+
+interface MonitoredEffect {
+    readonly id: number;
+    readonly parent: MonitoredEffect | null;
+    readonly descriptor: Effect;
+    readonly children: MonitoredEffect[];
+    isPending: boolean;
+}
+
+function isInitCompleted(effects: readonly MonitoredEffect[]): boolean {
+    return effects.every(isTreeResolvedOrTake);
+}
+
+function isTreeResolvedOrTake(effect: MonitoredEffect): boolean {
+    return (effect.children.length && effect.children.every(isTreeResolvedOrTake)) || isResolvedOrTake(effect);
+}
+
+function isResolvedOrTake(effect: MonitoredEffect): boolean {
+    return !effect.isPending || effect.descriptor.type === 'TAKE';
+}
+
+function trimResolvedEffects(effects: readonly MonitoredEffect[]): MonitoredEffect[] {
+    const pendingEffects: MonitoredEffect[] = [];
+    for (const effect of effects) {
+        const pendingChildren = trimResolvedEffects(effect.children);
+        if ((!effect.children.length || pendingChildren.length) && !isResolvedOrTake(effect)) {
+            pendingEffects.push({
+                ...effect,
+                children: pendingChildren,
+            });
+        }
+    }
+    return pendingEffects;
+}
+
+function formatEffectForest(rootEffects: readonly MonitoredEffect[]): string {
+    return formatLevel(rootEffects, '').join('\n');
+
+    function formatLevel(effects: readonly MonitoredEffect[], indentation: string): string[] {
+        const lines: string[] = [];
+        for (const effect of effects) {
+            const formattedEffect = `#${effect.id} ${effect.descriptor.type}`;
+            const state = effect.isPending ? 'pending' : 'resolved';
+            switch (effect.descriptor.type) {
+                case 'FORK':
+                case 'CALL':
+                    lines.push(`${indentation}${formattedEffect}: ${effect.descriptor.payload.fn.name} ${state}`);
+                    break;
+                default:
+                    lines.push(`${indentation}${formattedEffect} ${state}`);
+                    break;
+            }
+            lines.push(...formatLevel(effect.children, `  ${indentation}`));
+        }
+        return lines;
+    }
+}

--- a/packages/wrapper/src/initSagaMonitorFactory.ts
+++ b/packages/wrapper/src/initSagaMonitorFactory.ts
@@ -66,6 +66,14 @@ export function createInitSagaMonitor(timeout = DEFAULT_TIMEOUT): InitSagaMonito
         initCompletion,
         monitor,
         start(): void {
+            // Implementation note: While it is possible, in certain situations, to auto-start the monitor at the right moment (a saga triggers an effect that
+            // is a CPS or a CALL to a function that is not a generator and does not resolve in the next tick, i.e. is asynchronous; or all sagas have
+            // terminated), this would not be compatible with all use cases, e.g. a page dispatching an action, that makes sagas do anything meaningful at
+            // all, only in certain conditions.
+            // A tempting alternative is to start the monitor asynchronously in the next tick after it has been created, however, this would not be compatible
+            // with the use case of a page component's getXXXProps asynchronously dispatching a redux action that would start the sagas to do their work.
+            // Ergo, to mitigate any possible confusion caused by this behavior, this is not even an opt-in feature. At least, not yet.
+
             if (isStarted) {
                 throw new Error('This init monitor has already been started. Please create a new one for every redux store.');
             }

--- a/packages/wrapper/src/initSagaMonitorFactory.ts
+++ b/packages/wrapper/src/initSagaMonitorFactory.ts
@@ -11,7 +11,7 @@ export interface InitSagaMonitor {
     readonly start: () => void;
 }
 
-export default function createInitSagaMonitor(timeout = DEFAULT_TIMEOUT): InitSagaMonitor {
+export function createInitSagaMonitor(timeout = DEFAULT_TIMEOUT): InitSagaMonitor {
     const rootEffects: MonitoredEffect[] = [];
     const effectIdToEffectIndex = new Map<number, MonitoredEffect>();
 

--- a/packages/wrapper/src/initSagaMonitorFactory.ts
+++ b/packages/wrapper/src/initSagaMonitorFactory.ts
@@ -124,8 +124,14 @@ export function createInitSagaMonitor(timeout = DEFAULT_TIMEOUT): InitSagaMonito
 
     function checkInitCompletion(): void {
         if (isStarted && !isResolved && isInitCompleted(rootEffects)) {
-            isResolved = true;
-            initCompletionResolver();
+            // We wait a micro tick to ensure that an ongoing init saga waiting for a redux action currently being delivered is not prematurely marked as
+            // completed.
+            Promise.resolve().then(() => {
+                if (!isResolved && isInitCompleted(rootEffects)) {
+                    isResolved = true;
+                    initCompletionResolver();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
The current usage example does not correctly handle some cases of sagas initializing the store. If saga `A` is waiting for the result of an asynchronous operation done by saga `B`, with the result dispatched as a redux action, saga `A` would never receive the result-carrying action because the `END` action is dispatched too soon in such a case. (This pattern enables multiple sagas to receive the result of `A` while having to execute `A` only once).

This PR handles such use cases by introducing a saga monitor that observes saga activity and reports once every saga has either terminated or is waiting for a redux action (this is an assumption that the saga at hand awaits a user action that would dispatch the expected action, and can be terminated using the `END` action).