### PR TITLE
Update broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Moreover it allows to properly handle complex cases like `App.getInitialProps` (
 
 Library provides uniform interface no matter in which Next.js lifecycle method you would like to use the `Store`.
 
-In Next.js example https://github.com/vercel/next.js/blob/canary/examples/with-redux/store.js#L55 store is being replaced on navigation. Redux will re-render components even with memoized selectors (`createSelector` from `recompose`) if `store` is replaced: https://codesandbox.io/s/redux-store-change-kzs8q, which may affect performance of the app by causing a huge re-render of everything, even what did not change. This library makes sure `store` remains the same.
+In Next.js example https://github.com/vercel/next.js/blob/canary/examples/with-redux-thunk/store.js#L23 store is being replaced on navigation. Redux will re-render components even with memoized selectors (`createSelector` from `recompose`) if `store` is replaced: https://codesandbox.io/s/redux-store-change-kzs8q, which may affect performance of the app by causing a huge re-render of everything, even what did not change. This library makes sure `store` remains the same.
 
 # Installation
 


### PR DESCRIPTION
Hi,

While reading through the README.md file, I noticed a broken link in the last paragraph of the `Motivation` section:

`In Next.js example ...` https://github.com/vercel/next.js/blob/canary/examples/with-redux/store.js#L55

After looking around in the next.js repository, I noticed that the `with-redux` example got replaced with a [redux-toolkit](https://github.com/vercel/next.js/tree/canary/examples/with-redux) one.
I tried to find an example that closely matched the [previous one](https://github.com/vercel/next.js/blob/56292234075051e8b9967c39c8a0d99eb57aa54d/examples/with-redux/store.js#L55), I found a couple and decided to update the link with the example from `with-redux-thunk` (see below):

* [with-redux-thunk](https://github.com/vercel/next.js/blob/canary/examples/with-redux-thunk/store.js#L23)
* [with-redux-persist](https://github.com/vercel/next.js/blob/canary/examples/with-redux-persist/store.js#L112) _uses makeStore_

Feel free to ignore this PR if the updated example isn't good.

Thank you.
