### PR TITLE
Added convenience methods for redux-toolkit typescript users

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,12 @@ const makeStore = () =>
 
 export type AppStore = ReturnType<typeof makeStore>;
 export type AppState = ReturnType<AppStore['getState']>;
+export type AppDispatch = AppStore['dispatch'];
 export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, AppState, unknown, Action>;
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 export const fetchSubject =
   (id: any): AppThunk =>


### PR DESCRIPTION
I saw that there were some minor code missing from the documentation for redux toolkit typescript users. I'm not sure about the compatibility - here's my relevant package.json:

```
  "@reduxjs/toolkit": "^1.9.2",
    "next": "^13.1.5",
    "next-redux-wrapper": "^8.1.0",
```


I modified the documentation so it better matched these redux toolkit docs - [Correct typings for the Dispatch type](https://redux-toolkit.js.org/usage/usage-with-typescript#correct-typings-for-the-dispatch-type). Not sure if this is totally necessary but I figure it may help people who are starting a new project like I am.