### PR TITLE
Add react-redux batch

### DIFF
--- a/packages/wrapper/src/index.tsx
+++ b/packages/wrapper/src/index.tsx
@@ -9,7 +9,7 @@ import {
     NextComponentType,
     NextPageContext,
 } from 'next';
-import {useDispatch} from 'react-redux';
+import {useDispatch,batch} from 'react-redux';
 
 /**
  * Quick note on Next.js return types:
@@ -186,14 +186,16 @@ const getStates = ({
 };
 
 const dispatchStates = (dispatch: Dispatch, states: PageProps, config: Config<any>) =>
-    getStates(states).forEach((actions, source) =>
-        getDeserialized(actions, config).forEach(action =>
-            dispatch({
-                ...action,
-                meta: {...(action as any).meta, source},
-            }),
-        ),
-    );
+    batch(() => {
+        getStates(states).forEach((actions, source) =>
+            getDeserialized(actions, config).forEach(action =>
+                dispatch({
+                    ...action,
+                    meta: {...(action as any).meta, source},
+                }),
+            ),
+        )
+    });
 
 export const createWrapper = <S extends Store>(makeStore: MakeStore<S>, config: Config<S> = {}) => {
     const makeProps = async function <P extends Object>({


### PR DESCRIPTION
According react-redux docs this is not required with React 18 in use: https://react-redux.js.org/api/batch
But I had some doubts as explained below:

-------------

_As of React 18, React has improved its batching mechanism for React state updates. That means the useState and useReducer hooks in React, the updates to those state setters will be batched automatically when they occur inside React event handlers or lifecycle methods._

_Redux itself does not use React's state mechanism. It uses its own store to manage the global state. When you dispatch actions in Redux, and if those actions lead to state changes in the Redux store, you will typically want your React components to re-render to reflect those changes. This is where the react-redux library comes in. It connects your React components to the Redux store and ensures re-renders when necessary._

_Before React 18, if multiple Redux actions were dispatched outside of a React event handler (e.g., in async functions), you might experience multiple re-renders in your React components, as react-redux wouldn't batch these updates by default. To mitigate this, react-redux provided a batch function to group together multiple Redux updates, ensuring a single re-render for all of them._

_With React 18's enhanced batching mechanism, the React updates triggered by Redux state changes might be batched more effectively, even if they occur outside React event handlers or lifecycle methods. That's why the recommendation might be there._

_However, there's one thing to note: Just because React 18 batches its state updates more effectively doesn't mean it will batch all updates from any possible source. The extent to which React 18's batching applies to react-redux updates would depend on the integration details of the react-redux library with React._

-------------
Stack Overflow link saying the opposite: https://stackoverflow.com/questions/76313875/react-redux-batch-on-react-v-18

So in any case even in case of React 17 would it not make sense to leverage batch?

Also one consideration: While the new version 9 uses useLayoutEffect to ensure the effect has fired before the next repaint it does not mean that batching is not required as still the store is getting updated.

All of this might be totally wrong, so looking forward to your feedback on this.
I had tested this on my local could not clearly make out an improvement.

For my use case I am using RTK which has a autoBatchEnhancer so not sure if this is would not be true even in React 17.